### PR TITLE
[Setting]Theme 설정 수정

### DIFF
--- a/src/styles/Theme.ts
+++ b/src/styles/Theme.ts
@@ -1,20 +1,34 @@
 import { css, DefaultTheme } from 'styled-components';
 
 const colors = {
-  ModdyBlue: '#236ffF',
+  ModdyBlue: '#236fff',
   ModdyBlue2: '#91b7ff',
   ModdyBlue3: '#d3e2ff',
   ModdyBlue4: '#F4f8ff',
   ModdySky: '#6ae4ff',
   ModdyPurple: '#a38eff',
+  Kakao: '#f3dd24',
+  ModdyGradient3: 'linear-gradient(152deg, #6AE4FF -45.76%, #236FFF 25.9%, #236FFF 50.94%, #A38EFF 120.01%)',
 
-  ModdyBk: '#000000',
+  ModdyBk: '#1d2330',
   ModdyWt: '#ffffff',
-  ModdyGray100: '#1d2330',
   ModdyGray50: '#8e9197',
   ModdyGray20: '#d2d3d6',
   ModdyGray10: '#e8e9ea',
   ModdyGray05: '#f4f4f5',
+  ModdyBk50: 'rgba(0, 0, 0, 0.50)',
+  ModdyWt30: 'rgba(255, 255, 255, 0.30)',
+};
+
+const effects = {
+  Shadow1: '0px 0px 8px 0px rgba(0, 0, 0, 0.24)',
+  Shadow2: '0px 0px 8px 0px rgba(35, 111, 255, 0.24)',
+  Shadow3: '0px 0px 4px 0px rgba(35, 111, 255, 0.24)',
+  Shadow4: '0px 0px 4px 0px rgba(0, 0, 0, 0.24)',
+  ShadowHome: '0px 3px 10px 0px rgba(0, 0, 0, 0.20)',
+  MainCtaShadow: '0px 0px 8px 0px rgba(0, 0, 0, 0.24)',
+  MainCtaBlur: 'blur(5px);',
+  Graphic: '0px 0px 30px 0px rgba(35, 111, 255, 0.70)',
 };
 
 const fonts = {
@@ -364,5 +378,6 @@ const fonts = {
 const theme: DefaultTheme = {
   colors,
   fonts,
+  effects,
 };
 export default theme;

--- a/src/styles/style.d.ts
+++ b/src/styles/style.d.ts
@@ -9,14 +9,28 @@ declare module 'styled-components' {
       ModdyBlue4: string;
       ModdySky: string;
       ModdyPurple: string;
+      Kakao: string;
+      ModdyGradient3: string;
       ModdyBk: string;
       ModdyWt: string;
-      ModdyGray100: string;
       ModdyGray50: string;
       ModdyGray20: string;
       ModdyGray10: string;
       ModdyGray05: string;
+      ModdyBk50: string;
+      ModdyWt30: string;
     };
+    effects: {
+      Shadow1: string;
+      Shadow2: string;
+      Shadow3: string;
+      Shadow4: string;
+      ShadowHome: string;
+      MainCtaShadow: string;
+      MainCtaBlur: string;
+      Graphic: string;
+    };
+
     fonts: {
       Title01: SerializedStyles;
       Title02: SerializedStyles;

--- a/src/styles/style.d.ts
+++ b/src/styles/style.d.ts
@@ -3,32 +3,32 @@ import 'styled-components';
 declare module 'styled-components' {
   export interface DefaultTheme {
     colors: {
-      ModdyBlue: string;
-      ModdyBlue2: string;
-      ModdyBlue3: string;
-      ModdyBlue4: string;
-      ModdySky: string;
-      ModdyPurple: string;
-      Kakao: string;
-      ModdyGradient3: string;
-      ModdyBk: string;
-      ModdyWt: string;
-      ModdyGray50: string;
-      ModdyGray20: string;
-      ModdyGray10: string;
-      ModdyGray05: string;
-      ModdyBk50: string;
-      ModdyWt30: string;
+      moddy_blue: string;
+      moddy_blue2: string;
+      moddy_blue3: string;
+      moddy_blue4: string;
+      moddy_sky: string;
+      moddy_purple: string;
+      kakao: string;
+      moddy_gradient3: string;
+      moddy_bk: string;
+      moddy_wt: string;
+      moddy_gray50: string;
+      moddy_gray20: string;
+      moddy_gray10: string;
+      moddy_gray05: string;
+      moddy_bk50: string;
+      moddy_wt30: string;
     };
     effects: {
-      Shadow1: string;
-      Shadow2: string;
-      Shadow3: string;
-      Shadow4: string;
-      ShadowHome: string;
-      MainCtaShadow: string;
-      MainCtaBlur: string;
-      Graphic: string;
+      shadow1: string;
+      shadow2: string;
+      shadow3: string;
+      shadow4: string;
+      shadow_home: string;
+      main_cta_shadow: string;
+      main_cta_blur: string;
+      graphic: string;
     };
 
     fonts: {


### PR DESCRIPTION
<!-- PR의 제목은 "[페이지명] 구현내용 " 으로, 연결되는 이슈 제목과 동일하게 가져가시면 됩니다! -->

## ▶️ Related Issue

- close #16 

## ✨ DONE Task

- [x] Effect 추가
- [x] Color 추가 및 수정

<br />

## 💎 PR Point

```typescript
const Example = styled.div`

  background: ${({ theme }) => theme.colors.ModdyGradient3};
  box-shadow: ${({ theme }) => theme.effects.MainCtaShadow};
  backdrop-filter: ${({ theme }) => theme.effects.MainCtaBlur};
`;
``` 
- moddyGradient가 추가되었습니다! 해당 컬러를 이용할 때에는 `background-color`가 아닌 `background`라고 적어야 적용되더라구요! 
혹시 사용하실 때 필요하실까봐 적어둡니다. 

2. 그리구 effect 두가지가 적용된 효과가 딱 하나 있는데 이걸 따로 객체로 빼버리면 theme 사용이 오히려 불편할 것 같아서
`MainCtaShadow `와  `MainCtaBlur`로 구분해두었으니 위에 코드처럼 적어서 효과 적용해주시면 됩니다! 

<img width="233" alt="스크린샷 2024-01-06 오전 4 29 36" src="https://github.com/TEAM-MODDY/moddy-web/assets/111034927/119613b8-39f6-4906-9a68-46f896d60ecf">

<br />


<br />

## 🖼️ Screenshot
