### PR TITLE
[Setting] 라우터 기능 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "postcss-syntax": "^0.36.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-router-dom": "^6.21.1",
     "styled-components": "^6.1.6",
     "stylelint": "^16.1.0",
     "stylelint-config-standard": "^36.0.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,11 +1,30 @@
+import { RouterProvider, createBrowserRouter } from 'react-router-dom';
 import { ThemeProvider } from 'styled-components';
 
+import ApplicationPage from './pages/ApplicationPage';
+import LoginPage from './pages/LoginPage';
+import MainPage from './pages/MainPage';
+import ModelInfoPage from './pages/ModelInfoPage';
+import MyPage from './pages/MyPage';
+import OfferInfoPage from './pages/OfferInfoPage';
+import SignUpPage from './pages/SignUpPage';
 import GlobalStyle from './styles/GlobalStyle';
 import theme from './styles/Theme';
+
+const router = createBrowserRouter([
+  { path: '/', element: <MainPage /> },
+  { path: '/login', element: <LoginPage /> },
+  { path: '/signup', element: <SignUpPage /> },
+  { path: '/modelinfo', element: <ModelInfoPage /> },
+  { path: '/application', element: <ApplicationPage /> },
+  { path: '/offerinfo', element: <OfferInfoPage /> },
+  { path: '/mypage', element: <MyPage /> },
+]);
 
 const App = () => {
   return (
     <>
+      <RouterProvider router={router} />
       <ThemeProvider theme={theme}>
         <GlobalStyle />
       </ThemeProvider>

--- a/src/pages/ApplicationPage.tsx
+++ b/src/pages/ApplicationPage.tsx
@@ -1,0 +1,5 @@
+const ApplicationPage = () => {
+  return <div></div>;
+};
+
+export default ApplicationPage;

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -1,0 +1,5 @@
+const LoginPage = () => {
+  return <div></div>;
+};
+
+export default LoginPage;

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -1,0 +1,5 @@
+const MainPage = () => {
+  return <div></div>;
+};
+
+export default MainPage;

--- a/src/pages/ModelInfoPage.tsx
+++ b/src/pages/ModelInfoPage.tsx
@@ -1,0 +1,5 @@
+const ModelInfoPage = () => {
+  return <div></div>;
+};
+
+export default ModelInfoPage;

--- a/src/pages/MyPage.tsx
+++ b/src/pages/MyPage.tsx
@@ -1,0 +1,5 @@
+const MyPage = () => {
+  return <div></div>;
+};
+
+export default MyPage;

--- a/src/pages/OfferInfoPage.tsx
+++ b/src/pages/OfferInfoPage.tsx
@@ -1,0 +1,5 @@
+const OfferInfoPage = () => {
+  return <div></div>;
+};
+
+export default OfferInfoPage;

--- a/src/pages/SignUpPage.tsx
+++ b/src/pages/SignUpPage.tsx
@@ -1,0 +1,5 @@
+const SignUpPage = () => {
+  return <div></div>;
+};
+
+export default SignUpPage;

--- a/yarn.lock
+++ b/yarn.lock
@@ -498,6 +498,11 @@
   resolved "https://registry.yarnpkg.com/@pkgr/core/-/core-0.1.0.tgz#7d8dacb7fdef0e4387caf7396cbd77f179867d06"
   integrity sha512-Zwq5OCzuwJC2jwqmpEQt7Ds1DTi6BWSwoGkbb1n9pO3hzb35BoJELx7c0T23iDkBGkh2e7tvOtjF3tr3OaQHDQ==
 
+"@remix-run/router@1.14.1":
+  version "1.14.1"
+  resolved "https://registry.yarnpkg.com/@remix-run/router/-/router-1.14.1.tgz#6d2dd03d52e604279c38911afc1079d58c50a755"
+  integrity sha512-Qg4DMQsfPNAs88rb2xkdk03N3bjK4jgX5fR24eHCTR9q6PrhZQZ4UJBPzCHJkIpTRN1UKxx2DzjZmnC+7Lj0Ow==
+
 "@rollup/pluginutils@^5.0.5":
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/@rollup/pluginutils/-/pluginutils-5.1.0.tgz#7e53eddc8c7f483a4ad0b94afb1f7f5fd3c771e0"
@@ -3042,6 +3047,21 @@ react-refresh@^0.14.0:
   version "0.14.0"
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.14.0.tgz#4e02825378a5f227079554d4284889354e5f553e"
   integrity sha512-wViHqhAd8OHeLS/IRMJjTSDHF3U9eWi62F/MledQGPdJGDhodXJ9PBLNGr6WWL7qlH12Mt3TyTpbS+hGXMjCzQ==
+
+react-router-dom@^6.21.1:
+  version "6.21.1"
+  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-6.21.1.tgz#58b459d2fe1841388c95bb068f85128c45e27349"
+  integrity sha512-QCNrtjtDPwHDO+AO21MJd7yIcr41UetYt5jzaB9Y1UYaPTCnVuJq6S748g1dE11OQlCFIQg+RtAA1SEZIyiBeA==
+  dependencies:
+    "@remix-run/router" "1.14.1"
+    react-router "6.21.1"
+
+react-router@6.21.1:
+  version "6.21.1"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-6.21.1.tgz#8db7ee8d7cfc36513c9a66b44e0897208c33be34"
+  integrity sha512-W0l13YlMTm1YrpVIOpjCADJqEUpz1vm+CMo47RuFX4Ftegwm6KOYsL5G3eiE52jnJpKvzm6uB/vTKTPKM8dmkA==
+  dependencies:
+    "@remix-run/router" "1.14.1"
 
 react@^18.2.0:
   version "18.2.0"


### PR DESCRIPTION
<!-- PR의 제목은 "[페이지명] 구현내용 " 으로, 연결되는 이슈 제목과 동일하게 가져가시면 됩니다! -->

## ▶️ Related Issue

- close #18 

## ✨ DONE Task

- [ ] 라우터 기능 추가

<br />

## 💎 PR Point

```tsx
const router = createBrowserRouter([
  { path: '/', element: <MainPage /> },
  { path: '/login', element: <LoginPage /> },
  { path: '/signup', element: <SignUpPage /> },
  { path: '/modelinfo', element: <ModelInfoPage /> },
  { path: '/application', element: <ApplicationPage /> },
  { path: '/offerinfo', element: <OfferInfoPage /> },
  { path: '/mypage', element: <MyPage /> },
]);
```
- 단순하게 각 페이지명으로 라우팅 되도록 만들었는데 login 이후에는 페이지 명 뒤에 파라미터가 붙어야 하는 걸 알지만 !!! 아직 API 명세서가 안 나왔기에 페이지명까지만 지어줬습니당 ! ! 