### PR TITLE
[Common] 공통 컴포넌트 - Header, CTA 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react';
 import { RouterProvider, createBrowserRouter } from 'react-router-dom';
 import { ThemeProvider } from 'styled-components';
 
@@ -22,6 +23,25 @@ const router = createBrowserRouter([
 ]);
 
 const App = () => {
+  const setScreenSize = () => {
+    // vh 관련
+    const vh = window.innerHeight * 0.01;
+    document.documentElement.style.setProperty('--vh', `${vh}px`);
+
+    // window width 관련
+    const windowWidth = window.innerWidth || document.documentElement.clientWidth || document.body.clientWidth;
+    const maxWidth = Math.min(375, windowWidth);
+    document.documentElement.style.setProperty('--app-max-width', `${maxWidth}px`);
+  };
+
+  useEffect(() => {
+    setScreenSize();
+    window.addEventListener('resize', setScreenSize);
+
+    return () => {
+      window.removeEventListener('resize', setScreenSize);
+    };
+  }, []);
   return (
     <>
       <ThemeProvider theme={theme}>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,8 +24,8 @@ const router = createBrowserRouter([
 const App = () => {
   return (
     <>
-      <RouterProvider router={router} />
       <ThemeProvider theme={theme}>
+        <RouterProvider router={router} />
         <GlobalStyle />
       </ThemeProvider>
     </>

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -1,13 +1,5 @@
-import Button from '../views/@common/components/Button';
-import Header from '../views/@common/components/Header';
-
 const MainPage = () => {
-  return (
-    <div>
-      <Header />
-      <Button />
-    </div>
-  );
+  return <div></div>;
 };
 
 export default MainPage;

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -1,5 +1,12 @@
+import Button from '../views/@common/components/Button';
+import Header from '../views/@common/components/Header';
+
 const MainPage = () => {
-  return <div></div>;
+  return (
+    <div>
+      <Button />
+    </div>
+  );
 };
 
 export default MainPage;

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -4,6 +4,7 @@ import Header from '../views/@common/components/Header';
 const MainPage = () => {
   return (
     <div>
+      <Header />
       <Button />
     </div>
   );

--- a/src/views/@common/components/Button.tsx
+++ b/src/views/@common/components/Button.tsx
@@ -1,9 +1,13 @@
 import styled from 'styled-components';
 
-const Button = () => {
+interface ButtonProps {
+  text: string;
+  isFixed: boolean;
+}
+const Button = ({ text, isFixed }: ButtonProps) => {
   return (
-    <S.ButtonLayout className="footer">
-      <button type="button">다음</button>
+    <S.ButtonLayout className="footer" $isFixed={isFixed}>
+      <button type="button">{text}</button>
     </S.ButtonLayout>
   );
 };
@@ -11,9 +15,11 @@ const Button = () => {
 export default Button;
 
 const S = {
-  ButtonLayout: styled.section`
+  ButtonLayout: styled.section<{ $isFixed: boolean }>`
     display: flex;
     justify-content: center;
+    position: ${({ $isFixed }) => ($isFixed ? 'fixed' : 'static')};
+    bottom: 0;
 
     width: 100%;
     padding: 0 1.5rem 4rem 1.6rem;

--- a/src/views/@common/components/Button.tsx
+++ b/src/views/@common/components/Button.tsx
@@ -1,0 +1,24 @@
+import styled from 'styled-components';
+
+const Button = () => {
+  return <S.ButtonLayout>다음</S.ButtonLayout>;
+};
+
+export default Button;
+
+const S = {
+  ButtonLayout: styled.section`
+    display: flex;
+    justify-content: center;
+    align-items: center;
+
+    width: 100%;
+    height: 5.2rem;
+    border-radius: 8px;
+
+    background-color: ${({ theme }) => theme.colors.moddy_blue};
+
+    color: ${({ theme }) => theme.colors.moddy_wt};
+    ${({ theme }) => theme.fonts.Headline01};
+  `,
+};

--- a/src/views/@common/components/Button.tsx
+++ b/src/views/@common/components/Button.tsx
@@ -6,7 +6,7 @@ interface ButtonProps {
 }
 const Button = ({ text, isFixed }: ButtonProps) => {
   return (
-    <S.ButtonLayout className="footer" $isFixed={isFixed}>
+    <S.ButtonLayout $isFixed={isFixed}>
       <button type="button">{text}</button>
     </S.ButtonLayout>
   );

--- a/src/views/@common/components/Button.tsx
+++ b/src/views/@common/components/Button.tsx
@@ -1,7 +1,11 @@
 import styled from 'styled-components';
 
 const Button = () => {
-  return <S.ButtonLayout>다음</S.ButtonLayout>;
+  return (
+    <S.ButtonLayout className="footer">
+      <button type="button">다음</button>
+    </S.ButtonLayout>
+  );
 };
 
 export default Button;
@@ -10,15 +14,23 @@ const S = {
   ButtonLayout: styled.section`
     display: flex;
     justify-content: center;
-    align-items: center;
 
     width: 100%;
-    height: 5.2rem;
-    border-radius: 8px;
+    padding: 0 1.5rem 4rem 1.6rem;
 
-    background-color: ${({ theme }) => theme.colors.moddy_blue};
+    & > button {
+      display: flex;
+      justify-content: center;
+      align-items: center;
 
-    color: ${({ theme }) => theme.colors.moddy_wt};
-    ${({ theme }) => theme.fonts.Headline01};
+      width: 100%;
+      padding: 1.5rem 0;
+      border-radius: 8px;
+
+      background-color: ${({ theme }) => theme.colors.moddy_blue};
+
+      color: ${({ theme }) => theme.colors.moddy_wt};
+      ${({ theme }) => theme.fonts.Headline01};
+    }
   `,
 };

--- a/src/views/@common/components/Header.tsx
+++ b/src/views/@common/components/Header.tsx
@@ -1,7 +1,17 @@
 import styled from 'styled-components';
 
+import { IcCloseBlack, IcLeftBlack } from '../assets/icons';
+
 const Header = () => {
-  return <S.HeaderLayout>Header</S.HeaderLayout>;
+  return (
+    <S.HeaderLayout>
+      <S.HeaderBox>
+        <IcLeftBlack />
+        <S.HeaderH1>헤더 제목</S.HeaderH1>
+        <IcCloseBlack />
+      </S.HeaderBox>
+    </S.HeaderLayout>
+  );
 };
 
 export default Header;
@@ -9,5 +19,17 @@ export default Header;
 const S = {
   HeaderLayout: styled.section`
     width: 100%;
+    height: 5rem;
+    padding: 0.9rem 1.6rem 1.7rem 1.5rem;
+  `,
+  HeaderBox: styled.div`
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+
+    width: 100%;
+  `,
+  HeaderH1: styled.h1`
+    ${({ theme }) => theme.fonts.Headline01};
   `,
 };

--- a/src/views/@common/components/Header.tsx
+++ b/src/views/@common/components/Header.tsx
@@ -1,0 +1,13 @@
+import styled from 'styled-components';
+
+const Header = () => {
+  return <S.HeaderLayout>Header</S.HeaderLayout>;
+};
+
+export default Header;
+
+const S = {
+  HeaderLayout: styled.section`
+    width: 100%;
+  `,
+};

--- a/src/views/@common/components/Header.tsx
+++ b/src/views/@common/components/Header.tsx
@@ -6,15 +6,17 @@ interface HeaderProps {
   isBackBtnExist?: boolean;
   isCloseBtnExist?: boolean;
   title: string;
+  backFn?: () => void;
+  closeFn?: () => void;
 }
 
-const Header = ({ isBackBtnExist, isCloseBtnExist, title }: HeaderProps) => {
+const Header = ({ isBackBtnExist, isCloseBtnExist, title, backFn, closeFn }: HeaderProps) => {
   return (
     <S.HeaderLayout>
       <S.HeaderBox>
-        {isBackBtnExist ? <IcLeftBlack /> : <S.HeaderBlankBox />}
+        <button onClick={backFn}>{isBackBtnExist ? <IcLeftBlack /> : <S.HeaderBlankBox />}</button>
         <S.HeaderH1>{title}</S.HeaderH1>
-        {isCloseBtnExist ? <IcCloseBlack /> : <S.HeaderBlankBox />}
+        <button onClick={closeFn}>{isCloseBtnExist ? <IcCloseBlack /> : <S.HeaderBlankBox />}</button>
       </S.HeaderBox>
     </S.HeaderLayout>
   );

--- a/src/views/@common/components/Header.tsx
+++ b/src/views/@common/components/Header.tsx
@@ -18,16 +18,17 @@ export default Header;
 
 const S = {
   HeaderLayout: styled.section`
+    position: fixed;
+    top: 0;
+    left: 0;
+
     width: 100%;
-    height: 5rem;
     padding: 0.9rem 1.6rem 1.7rem 1.5rem;
   `,
   HeaderBox: styled.div`
     display: flex;
     justify-content: space-between;
     align-items: center;
-
-    width: 100%;
   `,
   HeaderH1: styled.h1`
     ${({ theme }) => theme.fonts.Headline01};

--- a/src/views/@common/components/Header.tsx
+++ b/src/views/@common/components/Header.tsx
@@ -2,13 +2,19 @@ import styled from 'styled-components';
 
 import { IcCloseBlack, IcLeftBlack } from '../assets/icons';
 
-const Header = () => {
+interface HeaderProps {
+  isBackBtnExist?: boolean;
+  isCloseBtnExist?: boolean;
+  title: string;
+}
+
+const Header = ({ isBackBtnExist, isCloseBtnExist, title }: HeaderProps) => {
   return (
     <S.HeaderLayout>
       <S.HeaderBox>
-        <IcLeftBlack />
-        <S.HeaderH1>헤더 제목</S.HeaderH1>
-        <IcCloseBlack />
+        {isBackBtnExist ? <IcLeftBlack /> : <S.HeaderBlankBox />}
+        <S.HeaderH1>{title}</S.HeaderH1>
+        {isCloseBtnExist ? <IcCloseBlack /> : <S.HeaderBlankBox />}
       </S.HeaderBox>
     </S.HeaderLayout>
   );
@@ -21,9 +27,12 @@ const S = {
     position: fixed;
     top: 0;
     left: 0;
+    z-index: 1;
 
     width: 100%;
     padding: 0.9rem 1.6rem 1.7rem 1.5rem;
+
+    background-color: ${({ theme }) => theme.colors.moddy_wt};
   `,
   HeaderBox: styled.div`
     display: flex;
@@ -32,5 +41,9 @@ const S = {
   `,
   HeaderH1: styled.h1`
     ${({ theme }) => theme.fonts.Headline01};
+  `,
+  HeaderBlankBox: styled.div`
+    width: 2.4rem;
+    height: 2.4rem;
   `,
 };


### PR DESCRIPTION
<!-- PR의 제목은 "[페이지명] 구현내용 " 으로, 연결되는 이슈 제목과 동일하게 가져가시면 됩니다! -->

## ▶️ Related Issue

- close #31 

## ✨ DONE Task

- [x] 헤더
- [x] 버튼

<br />

## 💎 PR Point
### Header
- header는 scroll과 무관하게 상단에 보여야하기 때문에 `position:fixed`로 구현하였습니다. 따라서 내부 컴포넌트를 위에서부터 쌓으면 header 위치와 무관하게 맨 위부터 쌓이기 때문에 최상단 공백에 header 높이인 `5rem` 만큼 띄워주어야 합니다. 
- ⭐️navigate 혹은 이탈 모달을 띄우기 위한 onClick 함수를 넣어야하실텐데요, 
  - **뒤로가기** 버튼에 넣을 onClick함수는 `backFn`에 
  - **닫기** 버튼에 넣을 onClick함수는 `closeFn`에 담아주시면 됩니다. 
  - 두 함수의 type은 `()=>void` 로 맞춰주셔야 합니다. 
- ⭐️사용법
  - isBackBtnExist : 뒤로가기 버튼 필요 여부 (boolean) 
  - isCloseBtnExist : 닫기 버튼 필요 여부 (boolean) 
  - title : 헤더에 들어가는 텍스트. 없을 시 빈 문자열 
  - backFn : 뒤로가기 버튼 onClick
  - closeFn : 닫기 버튼 onClick

```jsx
<Header isBackBtnExist={true} isCloseBtnExist={false} title="헤더 제목" />
<Header isBackBtnExist title="자유롭게" />
<Header
  isBackBtnExist={true}
  isCloseBtnExist={true}
  title="제목 내용"
  backFn={() => {
    navigate(-1);
  }}
/>
```

### Button
- 버튼은 현재 양옆 1.5rem의 공백, 아래엔 4rem의 공백, **상위엔 공백 없이** 레이아웃이 설정되어있습니다. 
- ⭐️ 뷰에 따라 position을 fixed로 줘야하는 뷰가 있고 (스크롤 없는 뷰), 주지 않아야 하는 뷰가 있습니다 (스크롤 있는 뷰). 스크롤 없는 뷰여서 콘텐츠 길이와 무관하게 아래에 고정시켜야할 경우 isFixed 값을 true로 주시고, 스크롤이 생기도록 콘텐츠가 긴 뷰에서는 isFixed false로 주시면 됩니다. 

```jsx
<Button text="다음" isFixed={true} />
<Button text="다음" isFixed />
<Button text="계속하기" />
```

<br />


