### PR TITLE
[Common] ProgressBar, Button, Toast 수정사항 반영

### DIFF
--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -1,5 +1,11 @@
+import ProgressBar from '../views/@common/components/ProgressBar';
+
 const MainPage = () => {
-  return <div></div>;
+  return (
+    <div>
+      <ProgressBar whole={5} current={2} />
+    </div>
+  );
 };
 
 export default MainPage;

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -1,13 +1,5 @@
-import Button from '../views/@common/components/Button';
-import ProgressBar from '../views/@common/components/ProgressBar';
-
 const MainPage = () => {
-  return (
-    <div>
-      <ProgressBar whole={5} current={2} />
-      <Button text="다음" onClickFn={() => console.log('test')} isFixed shadow />
-    </div>
-  );
+  return <div></div>;
 };
 
 export default MainPage;

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -1,9 +1,11 @@
+import Button from '../views/@common/components/Button';
 import ProgressBar from '../views/@common/components/ProgressBar';
 
 const MainPage = () => {
   return (
     <div>
       <ProgressBar whole={5} current={2} />
+      <Button text="다음" onClickFn={() => console.log('test')} />
     </div>
   );
 };

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -5,7 +5,7 @@ const MainPage = () => {
   return (
     <div>
       <ProgressBar whole={5} current={2} />
-      <Button text="다음" onClickFn={() => console.log('test')} />
+      <Button text="다음" onClickFn={() => console.log('test')} isFixed shadow />
     </div>
   );
 };

--- a/src/styles/Theme.ts
+++ b/src/styles/Theme.ts
@@ -27,12 +27,14 @@ const effects = {
   shadow2: '0px 0px 8px 0px rgba(35, 111, 255, 0.24)',
   shadow3: '0px 0px 4px 0px rgba(35, 111, 255, 0.24)',
   shadow4: '0px 0px 4px 0px rgba(0, 0, 0, 0.24)',
+  shadow5: '2px 2px 8px rgba(0, 0, 0, 0.24)',
+  shadow6: '2px 2px 8px rgba(0, 0, 0, 0.24)',
+  shadow7: '0px -2px 8px rgba(0, 0, 0, 0.08)',
   shadow_home: '0px 3px 10px 0px rgba(0, 0, 0, 0.20)',
   main_cta_shadow: '0px 0px 8px 0px rgba(0, 0, 0, 0.24)',
   main_cta_blur: 'blur(5px);',
   graphic: '0px 0px 30px 0px rgba(35, 111, 255, 0.70)',
 };
-
 const fonts = {
   Title01: css`
     font-family:

--- a/src/styles/style.d.ts
+++ b/src/styles/style.d.ts
@@ -28,6 +28,9 @@ declare module 'styled-components' {
       shadow2: string;
       shadow3: string;
       shadow4: string;
+      shadow5: string;
+      shadow6: string;
+      shadow7: string;
       shadow_home: string;
       main_cta_shadow: string;
       main_cta_blur: string;

--- a/src/views/@common/components/Button.tsx
+++ b/src/views/@common/components/Button.tsx
@@ -30,7 +30,9 @@ const S = {
 
     width: 100%;
     max-width: 43rem;
-    padding: 0 1.5rem 4rem 1.6rem;
+    padding: 0.8rem 1.5rem 4rem 1.6rem;
+
+    background-color: ${({ theme }) => theme.colors.moddy_wt};
 
     & > button {
       display: flex;

--- a/src/views/@common/components/Button.tsx
+++ b/src/views/@common/components/Button.tsx
@@ -38,7 +38,7 @@ const S = {
     padding: 0.8rem 1.5rem 4rem 1.6rem;
 
     background-color: ${({ theme }) => theme.colors.moddy_wt};
-    box-shadow: ${({ theme }) => theme.effects.shadow7};
+    box-shadow: ${({ theme, $shadow }) => ($shadow ? theme.effects.shadow7 : 'none')};
 
     & > button {
       display: flex;

--- a/src/views/@common/components/Button.tsx
+++ b/src/views/@common/components/Button.tsx
@@ -7,10 +7,11 @@ interface ButtonProps {
   onClickFn: () => void;
   disabled?: boolean;
   icon?: ReactNode;
+  shadow?: boolean;
 }
-const Button = ({ text, isFixed, onClickFn, disabled, icon }: ButtonProps) => {
+const Button = ({ text, isFixed, onClickFn, disabled, icon, shadow }: ButtonProps) => {
   return (
-    <S.ButtonLayout $isFixed={isFixed} $disabled={disabled}>
+    <S.ButtonLayout $isFixed={isFixed} $disabled={disabled} $shadow={shadow}>
       <button type="button" onClick={onClickFn} disabled={disabled}>
         {icon}
         {text}
@@ -22,7 +23,11 @@ const Button = ({ text, isFixed, onClickFn, disabled, icon }: ButtonProps) => {
 export default Button;
 
 const S = {
-  ButtonLayout: styled.section<{ $isFixed: boolean | undefined; $disabled: boolean | undefined }>`
+  ButtonLayout: styled.section<{
+    $isFixed: boolean | undefined;
+    $disabled: boolean | undefined;
+    $shadow: boolean | undefined;
+  }>`
     display: flex;
     justify-content: center;
     position: ${({ $isFixed }) => ($isFixed ? 'fixed' : 'static')};
@@ -33,6 +38,7 @@ const S = {
     padding: 0.8rem 1.5rem 4rem 1.6rem;
 
     background-color: ${({ theme }) => theme.colors.moddy_wt};
+    box-shadow: ${({ theme }) => theme.effects.shadow7};
 
     & > button {
       display: flex;

--- a/src/views/@common/components/Input.tsx
+++ b/src/views/@common/components/Input.tsx
@@ -5,13 +5,21 @@ import { IcCheckBlue } from '../assets/icons';
 
 interface InputProps {
   placeholderText: string;
+  onChangeFn: (value: string) => void;
 }
 
-const Input = ({ placeholderText }: InputProps) => {
+const Input = ({ placeholderText, onChangeFn }: InputProps) => {
   const [name, setName] = useState('');
   return (
     <S.InputLayout>
-      <S.Input placeholder={placeholderText} value={name} onChange={(e) => setName(e.target.value)} />
+      <S.Input
+        placeholder={placeholderText}
+        value={name}
+        onChange={(e) => {
+          setName(e.target.value);
+          onChangeFn(e.target.value);
+        }}
+      />
       {name !== '' && <IcCheckBlue />}
     </S.InputLayout>
   );

--- a/src/views/@common/components/ProgressBar.tsx
+++ b/src/views/@common/components/ProgressBar.tsx
@@ -43,6 +43,7 @@ const S = {
   ProgressBarBox: styled.div`
     display: flex;
     gap: 1rem;
+    justify-content: center;
     align-items: center;
   `,
 };

--- a/src/views/@common/components/ProgressBar.tsx
+++ b/src/views/@common/components/ProgressBar.tsx
@@ -33,9 +33,12 @@ const S = {
     display: flex;
     justify-content: center;
     position: fixed;
-    top: 5.4rem;
+    top: 5rem;
 
     width: 100%;
+    padding: 0.5rem;
+
+    background-color: ${({ theme }) => theme.colors.moddy_wt};
   `,
   ProgressBarBox: styled.div`
     display: flex;

--- a/src/views/@common/components/TextArea200.tsx
+++ b/src/views/@common/components/TextArea200.tsx
@@ -3,15 +3,19 @@ import styled from 'styled-components';
 
 interface TextArea200Props {
   placeholderText: string;
+  onChangeFn: (value: string) => void;
 }
 
-const TextArea200 = ({ placeholderText }: TextArea200Props) => {
+const TextArea200 = ({ placeholderText, onChangeFn }: TextArea200Props) => {
   const [textLength, setTextLength] = useState(0);
   return (
     <S.TextAreaLayout>
       <S.TextArea
         placeholder={placeholderText}
-        onChange={(e) => setTextLength(e.target.value.length)}
+        onChange={(e) => {
+          setTextLength(e.target.value.length);
+          onChangeFn(e.target.value);
+        }}
         maxLength={200}
       />
       <S.TextAreaSpan>

--- a/src/views/@common/components/ToastMessage.tsx
+++ b/src/views/@common/components/ToastMessage.tsx
@@ -35,6 +35,8 @@ const S = {
 
     width: 100%;
     height: 100vh;
+
+    background-color: ${({ theme }) => theme.colors.moddy_bk20};
   `,
   ToastSection: styled.section`
     display: flex;


### PR DESCRIPTION
<!-- PR의 제목은 "[페이지명] 구현내용 " 으로, 연결되는 이슈 제목과 동일하게 가져가시면 됩니다! -->

## ▶️ Related Issue

close #74 

## ✨ DONE Task

- [x] ProgressBar padding 0.5rem 추가, 배경색 wt , 세로 가운데 정렬 맞춤 
- [x] Button 영역 padding-top 0.4rem 추가, 배경색 wt
- [x] theme에 shadow 5 6 7 추가 
- [x] Button에 shadow props 추가  
- [x] ToastMessage dimmed 처리 


<br />

## 💎 PR Point
### Button 사용법 
▶️**interface**
```ts
interface ButtonProps {
  text: string;
  isFixed?: boolean;
  onClickFn: () => void;
  disabled?: boolean;
  icon?: ReactNode;
  shadow?: boolean;
}
```
▶️**사용법**

shadow 필요한 경우 shadow 넣기 

```tsx
<Button text="다음" onClickFn={() => console.log('test')} isFixed shadow />
```

<br />

## 🖼️ Screenshot
<img width="336" alt="스크린샷 2024-01-09 오전 12 30 30" src="https://github.com/TEAM-MODDY/moddy-web/assets/81505421/53c38889-cb37-417b-affd-063bd4bf174e">
