### PR TITLE
[LoginPage] 리드의 지조를 지키기 위해 만든 카카오 로그인 PR 

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,6 +14,7 @@ import SignUpPage from './pages/SignUpPage';
 import GlobalStyle from './styles/GlobalStyle';
 import theme from './styles/Theme';
 import ConfirmPage from './views/ApplicationPage/pages/ConfirmPage';
+import LoginCallback from './views/LoginPage/components/LoginCallback';
 import ModelOfferPage from './views/ModelInfoPage/components/ModelOfferPage';
 import OfferSentCompletePage from './views/ModelInfoPage/components/OfferSentCompletePage';
 import CheckOffer from './views/OfferInfoPage/components/CheckOffer';
@@ -21,6 +22,7 @@ import CheckOffer from './views/OfferInfoPage/components/CheckOffer';
 const router = createBrowserRouter([
   { path: '/', element: <MainPage /> },
   { path: '/login', element: <LoginPage /> },
+  { path: '/login/oauth2/code/kakao', element: <LoginCallback /> },
   { path: '/sign-up', element: <SignUpPage /> },
   { path: '/model-info', element: <ModelInfo /> },
   { path: '/sign-up', element: <SignUpPage /> },

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,10 +1,9 @@
-import React from 'react';
 import ReactDOM from 'react-dom/client';
 
 import App from './App.tsx';
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
-  <React.StrictMode>
+  <>
     <App />
-  </React.StrictMode>,
+  </>,
 );

--- a/src/views/@common/hooks/api.ts
+++ b/src/views/@common/hooks/api.ts
@@ -1,0 +1,30 @@
+import axios, { AxiosInstance } from 'axios';
+
+const api: AxiosInstance = axios.create({
+  baseURL: import.meta.env.VITE_BASE_URL,
+});
+
+const ACCESS_TOKEN = 'token';
+
+export const getToken = () => {
+  return localStorage.getItem(ACCESS_TOKEN);
+};
+
+export const setToken = (token: string) => {
+  localStorage.setItem(ACCESS_TOKEN, token);
+};
+
+export const removeToken = () => {
+  localStorage.removeItem(ACCESS_TOKEN);
+};
+
+// access token key 로컬스토리지에서 관리 예정
+// api.interceptors.request.use((config) => {
+//   const accessToken = getToken();
+//   if (accessToken) {
+//     config.headers['Authorization'] = `Bearer ${accessToken}`;
+//   }
+//   return config;
+// });
+
+export default api;

--- a/src/views/LoginPage/components/LoginButton.tsx
+++ b/src/views/LoginPage/components/LoginButton.tsx
@@ -1,14 +1,19 @@
 import styled from 'styled-components';
 
 import { ImgKakaotalk } from '../assets/images';
+import { KAKAO_LINK } from '../constants/kakaoLink';
 
 const LoginButton = () => {
+  const handleLogin = () => {
+    window.location.href = KAKAO_LINK;
+  };
+
   return (
     <S.LoginButtonLayout>
       <S.LoginButtonBtn
         type="button"
         onClick={() => {
-          console.log('카카오 로그인이 실행될겁니다');
+          handleLogin();
         }}>
         <ImgKakaotalk />
         카카오 로그인

--- a/src/views/LoginPage/components/LoginCallback.tsx
+++ b/src/views/LoginPage/components/LoginCallback.tsx
@@ -1,0 +1,8 @@
+import usePostLogin from '../hooks/usePostLogin';
+
+const LoginCallback = () => {
+  usePostLogin();
+  return <div></div>;
+};
+
+export default LoginCallback;

--- a/src/views/LoginPage/constants/kakaoLink.ts
+++ b/src/views/LoginPage/constants/kakaoLink.ts
@@ -1,0 +1,4 @@
+const KAKAO_REST_API_KEY = import.meta.env.VITE_REST_API_KEY;
+const KAKAO_REDIRECT_URI = import.meta.env.VITE_REDIRECT_URI;
+
+export const KAKAO_LINK = `https://kauth.kakao.com/oauth/authorize?client_id=${KAKAO_REST_API_KEY}&redirect_uri=${KAKAO_REDIRECT_URI}&response_type=code`;

--- a/src/views/LoginPage/hooks/type.ts
+++ b/src/views/LoginPage/hooks/type.ts
@@ -1,0 +1,19 @@
+export interface loginResProps {
+  data: {
+    code: number;
+    data: {
+      accessToken: string;
+      refreshToken: string;
+      role: string;
+    };
+  };
+}
+
+export interface loginErrorProps {
+  response: {
+    data: {
+      code: number;
+      message: string;
+    };
+  };
+}

--- a/src/views/LoginPage/hooks/usePostLogin.ts
+++ b/src/views/LoginPage/hooks/usePostLogin.ts
@@ -1,0 +1,34 @@
+import { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+import { loginErrorProps, loginResProps } from './type';
+
+import api from '@/views/@common/hooks/api';
+
+const usePostLogin = () => {
+  const KAKAO_CODE = new URL(window.location.href).searchParams.get('code');
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    api
+      .post('/auth/login', null, {
+        headers: {
+          Authorization: `Bearer ${KAKAO_CODE}`,
+        },
+      })
+      .then((res: loginResProps) => {
+        console.log('로그인 성공');
+        console.log(res);
+        // 로그인완료되고 메인뷰로 이동
+      })
+      .catch((err: loginErrorProps) => {
+        if (err.response.data.code === 404) {
+          navigate('/sign-up');
+        } else {
+          navigate('/error');
+        }
+      });
+  }, []);
+};
+
+export default usePostLogin;


### PR DESCRIPTION
<!-- PR의 제목은 "[페이지명] 구현내용 " 으로, 연결되는 이슈 제목과 동일하게 가져가시면 됩니다! -->

## ▶️ Related Issue

close #122 

## ✨ DONE Task

- [x] 카카오 로그인 구현 
- [x] 커밋 옮기기 수작업 

<br />

## 💎 PR Point
### 💈 카카오 로그인 >< 
**1️⃣ 서버에게 받은 Rest api key와 Redirect URI로 카카오 로그인 링크를 생성한다.** 
```ts
export const KAKAO_LINK = `https://kauth.kakao.com/oauth/authorize?client_id=${KAKAO_REST_API_KEY}&redirect_uri=${KAKAO_REDIRECT_URI}&response_type=code`;
```

**2️⃣ 로그인 버튼 onClick 에 카카오 로그인 링크로 이동하는 handler를 연결해준다.** 

```ts
const handleLogin = () => {
    window.location.href = KAKAO_LINK;
  };
```

3️⃣ 로그인을 진행하면 **링크가 이동하면서 서버가 줬던 redirect uri로 이동**하는데, 주소 뒤 queryString으로 code={인가코드}가 붙는다. 

<img width="1142" alt="스크린샷 2024-01-10 오후 10 14 54" src="https://github.com/TEAM-MODDY/moddy-web/assets/81505421/6401776c-b8d3-4116-9630-21345d5209f6">

**4️⃣ redirect uri로 이동했을 때 실행할 컴포넌트를 생성한다**
```ts
{ path: '/login/oauth2/code/kakao', element: <LoginCallback /> }
```
```tsx
import usePostLogin from '../hooks/usePostLogin';

const LoginCallback = () => {
  usePostLogin(); // 인가코드를 서버에게 보내주는 post 통신 hook 
  return <div></div>;
};

export default LoginCallback;
```

**5️⃣ 인가코드를 서버에게 보내주는 post 통신 hook을 생성한다.** 
코드의 로직은 다음과 같다. 
- queryString 파싱해서 인가코드 추출하기 
```ts
  const KAKAO_CODE = new URL(window.location.href).searchParams.get('code');
```
- 서버가 요청한 형태에 맞춰서 인가코드를 담아 post를 보낸다 
  (모디의 경우, request headers의 Authorization에 인가코드를 담기로 했다) 
  (request body는 없어서 null로 넣어줬다) 
```ts
useEffect(() => {
    api
      .post(' 서버 엔드포인트', null, {
        headers: {
          Authorization: `Bearer ${KAKAO_CODE}`,
        },
      })
      .then((res) => {
        // 로그인 성공 
      })
      .catch((err) => {
        // 에러 처리 
  }, []);
```

<br/>

### 💈 브랜치 옮기기 >< 
commit만 한 상황이라면 cherry-pick으로 쉽게 옮겼겠지만 이미 푸시까지 해버려서 수작업으로 옮겨주었습니다. 
1. 잘못 push한 브랜치에서 git reset 으로 잘못 올라간 커밋 다 취소 -> 작업 내용 다 변경사항 (untracked)로 바뀜
2. git add . 으로 작업한 내용 staging 
3. git stash로 staged files 임시저장 
4. git checkout 진짜 브랜치 
5. git stash apply로 임시저장한 파일 다시 불러오기 
6. 제대로된 git commit, git push 
7. 잘못된 브랜치로 돌아가서 강제 푸쉬 (커밋 취소된 상태를 remote에도 동기화)

<br />

## 🧨 Trouble Shooting
request body 없이 headers만 필요할 때, 꼭 body 자리에 null을 넣어줘야 한다. 
안넣으면 headers 객체를 body로 잘못 담아 보내게 된다. 

<br />

## 🖼️ Screenshot

https://github.com/TEAM-MODDY/moddy-web/assets/81505421/233fa0a3-d13a-4369-a98d-66155d80d8ae

