### PR TITLE
[MainPage] 다른 페이지로 이동했을 때 배경색 이슈 해결

### DIFF
--- a/src/styles/GlobalStyle.ts
+++ b/src/styles/GlobalStyle.ts
@@ -113,6 +113,10 @@ export const reset = css`
     display: none;
   }
 
+  #root {
+    background: ${({ theme }) => theme.colors.moddy_wt};
+  }
+
   body {
     line-height: 1;
 

--- a/src/views/MainPage/components/TopSheet.tsx
+++ b/src/views/MainPage/components/TopSheet.tsx
@@ -1,3 +1,4 @@
+import { useNavigate } from 'react-router-dom';
 import { styled } from 'styled-components';
 
 import { IcLogoHome, IcRightWhite, IcModdyuser } from '../assets/icons';
@@ -9,6 +10,7 @@ interface TopSheetProps {
 }
 const TopSheet = (props: TopSheetProps) => {
   const { userType, applyType } = props;
+  const navigate = useNavigate();
 
   const OnBoardingText = () => {
     if (userType === USER_TYPE.GUEST) {
@@ -55,7 +57,7 @@ const TopSheet = (props: TopSheetProps) => {
       <S.HeaderBox>
         <IcLogoHome />
         {userType === USER_TYPE.GUEST ? (
-          <S.LoginButton type="button">
+          <S.LoginButton type="button" onClick={() => navigate('/login')}>
             <S.LoginSpan>로그인하기</S.LoginSpan>
             <IcRightWhite />
           </S.LoginButton>

--- a/src/views/MainPage/hooks/useStatusBarColor.tsx
+++ b/src/views/MainPage/hooks/useStatusBarColor.tsx
@@ -1,8 +1,10 @@
 import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
 
 const useStatusBarColor = () => {
+  const location = useLocation();
+
   useEffect(() => {
-    document.body.style.background = '#3287FF';
     const handleScroll = () => {
       if (window.scrollY > 217) {
         document.body.style.backgroundColor = '#ffffff';
@@ -20,8 +22,15 @@ const useStatusBarColor = () => {
         }
       }
     };
-    window.addEventListener('scroll', handleScroll, false);
-  }, []);
+    if (location.pathname === '/') {
+      document.body.style.background = '#3287FF';
+      window.addEventListener('scroll', handleScroll);
+    }
+    return () => {
+      window.removeEventListener('scroll', handleScroll);
+      document.body.style.backgroundColor = '#ffffff';
+    };
+  }, [location.pathname]);
 };
 
 export default useStatusBarColor;


### PR DESCRIPTION
<!-- PR의 제목은 "[페이지명] 구현내용 " 으로, 연결되는 이슈 제목과 동일하게 가져가시면 됩니다! -->

## ▶️ Related Issue

close #123

## ✨ DONE Task

- [x] 다른 페이지할 때 배경색 복구
- [x] 다른 페이지할 때 스크롤 이벤트 해제

<br />

## 🧨 Trouble Shooting

`useEffect` 에서 return 문은 unmount시 발생할 행동이다
따라서 다음과 같이 작성하여  해결하였다

```javascript
return () => {
      window.removeEventListener('scroll', handleScroll);
      document.body.style.backgroundColor = '#ffffff';
 };
```
