### PR TITLE
[SignUpPage] 유저 입력 데이터 관리

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,23 +1,22 @@
 <!doctype html>
 <html lang="ko">
-  <head>
-    <meta charset="UTF-8" />
-    <!-- <link rel="icon" type="image/svg+xml" href="/vite.svg" /> -->
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      href="https://fonts.googleapis.com/css2?family=MuseoModerno:ital,wght@1,300;1,400&display=swap"
-      rel="stylesheet" />
-    <link
-      rel="stylesheet"
-      as="style"
-      crossorigin
-      href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/variable/pretendardvariable.min.css" />
-    <title>Moddy</title>
-  </head>
-  <body>
-    <div id="root"></div>
-    <script type="module" src="/src/main.tsx"></script>
-  </body>
+
+<head>
+  <meta charset="UTF-8" />
+  <!-- <link rel="icon" type="image/svg+xml" href="/vite.svg" /> -->
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0" />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=MuseoModerno:ital,wght@1,300;1,400&display=swap"
+    rel="stylesheet" />
+  <link rel="stylesheet" as="style" crossorigin
+    href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/variable/pretendardvariable.min.css" />
+  <title>Moddy</title>
+</head>
+
+<body>
+  <div id="root"></div>
+  <script type="module" src="/src/main.tsx"></script>
+</body>
+
 </html>

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "react-router-dom": "^6.21.1",
     "react-slick": "^0.29.0",
     "recoil": "^0.7.7",
+    "recoil-persist": "^5.1.0",
     "styled-components": "^6.1.6",
     "stylelint": "^16.1.0",
     "stylelint-config-standard": "^36.0.0",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.21.1",
     "react-slick": "^0.29.0",
+    "recoil": "^0.7.7",
     "styled-components": "^6.1.6",
     "stylelint": "^16.1.0",
     "stylelint-config-standard": "^36.0.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
 import { useEffect } from 'react';
 import { RouterProvider, createBrowserRouter } from 'react-router-dom';
+import { RecoilRoot } from 'recoil';
 import { ThemeProvider } from 'styled-components';
 
 import AgreementPage from './pages/AgreementPage';
@@ -57,10 +58,12 @@ const App = () => {
   }, []);
   return (
     <>
-      <ThemeProvider theme={theme}>
-        <RouterProvider router={router} />
-        <GlobalStyle />
-      </ThemeProvider>
+      <RecoilRoot>
+        <ThemeProvider theme={theme}>
+          <RouterProvider router={router} />
+          <GlobalStyle />
+        </ThemeProvider>
+      </RecoilRoot>
     </>
   );
 };

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -1,22 +1,25 @@
+import { useRecoilValue } from 'recoil';
 import { styled } from 'styled-components';
 
+import { APPLY_TYPE } from '../views/@common/utils/constants';
 import Banner from '../views/MainPage/components/Banner';
 import Contents from '../views/MainPage/components/Contents';
 import ReceivedOffer from '../views/MainPage/components/ReceivedOffer';
 import StatusBarForiOS from '../views/MainPage/components/StatusBarForiOS';
 import TopSheet from '../views/MainPage/components/TopSheet';
-import { APPLY_TYPE, USER_TYPE } from '../views/MainPage/constants/constants';
+
+import { userTypeState } from '@/recoil/atoms/signUpState';
 
 const MainPage = () => {
-  const userType = USER_TYPE.GUEST;
-  const applyType = APPLY_TYPE.RECEIVED;
+  const userType = useRecoilValue(userTypeState);
+  const applyType = APPLY_TYPE.NOT_YET;
 
   return (
     <MainPageLayout>
       <StatusBarForiOS />
-      <TopSheet userType={userType} applyType={applyType} />
+      <TopSheet applyType={applyType} />
       <Banner />
-      {userType === USER_TYPE.GUEST ? <Contents /> : <ReceivedOffer applyType={applyType} />}
+      {!userType ? <Contents /> : <ReceivedOffer applyType={applyType} />}
     </MainPageLayout>
   );
 };

--- a/src/recoil/atoms/signUpState.ts
+++ b/src/recoil/atoms/signUpState.ts
@@ -59,13 +59,15 @@ export const verifyCodeState = atom<verificationDataType>({
   },
 });
 
-interface preferRegionDataType {
-  data: string[];
+export interface preferRegionDataType {
+  data: boolean[];
+  verifyStatus: boolean;
 }
 
 export const preferRegionState = atom<preferRegionDataType>({
   key: 'preferRegion',
   default: {
     data: [],
+    verifyStatus: false,
   },
 });

--- a/src/recoil/atoms/signUpState.ts
+++ b/src/recoil/atoms/signUpState.ts
@@ -1,0 +1,71 @@
+import { atom } from 'recoil';
+import { recoilPersist } from 'recoil-persist';
+
+import { STATUS } from '@/views/SignUpPage/constants/requestStatus';
+export interface inputDataType {
+  data: string;
+  verifyStatus: boolean;
+}
+const { persistAtom } = recoilPersist();
+
+export const userTypeState = atom({
+  key: 'userType',
+  default: null,
+  effects_UNSTABLE: [persistAtom],
+});
+
+export const nameState = atom<inputDataType>({
+  key: 'name',
+  default: {
+    data: '',
+    verifyStatus: false,
+  },
+});
+
+export const birthYearState = atom<inputDataType>({
+  key: 'birthYear',
+  default: {
+    data: '',
+    verifyStatus: false,
+  },
+});
+
+export const genderState = atom<inputDataType>({
+  key: 'gender',
+  default: {
+    data: '',
+    verifyStatus: false,
+  },
+});
+
+interface verificationDataType {
+  data: string;
+  status: number;
+}
+
+export const phoneNumberState = atom<verificationDataType>({
+  key: 'phoneNumber',
+  default: {
+    data: '',
+    status: STATUS.NOT_AVAILABLE,
+  },
+});
+
+export const verifyCodeState = atom<verificationDataType>({
+  key: 'verityCode',
+  default: {
+    data: '',
+    status: STATUS.NOT_AVAILABLE,
+  },
+});
+
+interface preferRegionDataType {
+  data: string[];
+}
+
+export const preferRegionState = atom<preferRegionDataType>({
+  key: 'preferRegion',
+  default: {
+    data: [],
+  },
+});

--- a/src/views/@common/components/Input.tsx
+++ b/src/views/@common/components/Input.tsx
@@ -5,11 +5,12 @@ import { IcCheckBlue } from '../assets/icons';
 
 interface InputProps {
   placeholderText: string;
+  initialValue?: string;
   onChangeFn: (value: string) => void;
 }
 
-const Input = ({ placeholderText, onChangeFn }: InputProps) => {
-  const [name, setName] = useState('');
+const Input = ({ placeholderText, initialValue, onChangeFn }: InputProps) => {
+  const [name, setName] = useState(initialValue ? initialValue : '');
   return (
     <S.InputLayout>
       <S.Input

--- a/src/views/@common/hooks/api.ts
+++ b/src/views/@common/hooks/api.ts
@@ -1,0 +1,30 @@
+import axios, { AxiosInstance } from 'axios';
+
+const api: AxiosInstance = axios.create({
+  baseURL: import.meta.env.VITE_BASE_URL,
+});
+
+const ACCESS_TOKEN = 'token';
+
+export const getToken = () => {
+  return localStorage.getItem(ACCESS_TOKEN);
+};
+
+export const setToken = (token: string) => {
+  localStorage.setItem(ACCESS_TOKEN, token);
+};
+
+export const removeAccessToken = () => {
+  localStorage.removeItem(ACCESS_TOKEN);
+};
+
+// access token key 로컬스토리지에서 관리 예정
+api.interceptors.request.use((config) => {
+  const accessToken = getToken();
+  if (accessToken) {
+    config.headers['Authorization'] = `Bearer ${accessToken}`;
+  }
+  return config;
+});
+
+export default api;

--- a/src/views/@common/utils/constants.ts
+++ b/src/views/@common/utils/constants.ts
@@ -1,9 +1,3 @@
-export const USER_TYPE = {
-  GUEST: 0,
-  DESIGNER: 1,
-  MODEL: 2,
-};
-
 export const APPLY_TYPE = {
   NOT_YET: 0,
   WAITING: 1,

--- a/src/views/@common/utils/userType.ts
+++ b/src/views/@common/utils/userType.ts
@@ -1,0 +1,4 @@
+export const USER_TYPE = {
+  DESIGNER: 'designer',
+  MODEL: 'model',
+};

--- a/src/views/MainPage/components/ReceivedOffer.tsx
+++ b/src/views/MainPage/components/ReceivedOffer.tsx
@@ -1,6 +1,6 @@
 import { styled } from 'styled-components';
 
-import { APPLY_TYPE } from '../constants/constants';
+import { APPLY_TYPE } from '../../@common/utils/constants';
 
 import ApplicationCard from './ApplicationCard';
 

--- a/src/views/MainPage/components/TopSheet.tsx
+++ b/src/views/MainPage/components/TopSheet.tsx
@@ -1,19 +1,24 @@
 import { useNavigate } from 'react-router-dom';
+import { useRecoilValue } from 'recoil';
 import { styled } from 'styled-components';
 
+import { APPLY_TYPE } from '../../@common/utils/constants';
 import { IcLogoHome, IcRightWhite, IcModdyuser } from '../assets/icons';
-import { APPLY_TYPE, USER_TYPE } from '../constants/constants';
+
+import { userTypeState } from '@/recoil/atoms/signUpState';
+import { USER_TYPE } from '@/views/@common/utils/userType';
 
 interface TopSheetProps {
-  userType: number;
   applyType: number;
 }
+
 const TopSheet = (props: TopSheetProps) => {
-  const { userType, applyType } = props;
+  const userType = useRecoilValue(userTypeState);
+  const { applyType } = props;
   const navigate = useNavigate();
 
   const OnBoardingText = () => {
-    if (userType === USER_TYPE.GUEST) {
+    if (!userType) {
       return (
         <S.OnBoardingParagraph>
           헤어 디자이너와 모델,
@@ -56,7 +61,7 @@ const TopSheet = (props: TopSheetProps) => {
     <S.TopSheetLayout>
       <S.HeaderBox>
         <IcLogoHome />
-        {userType === USER_TYPE.GUEST ? (
+        {!userType ? (
           <S.LoginButton type="button" onClick={() => navigate('/login')}>
             <S.LoginSpan>로그인하기</S.LoginSpan>
             <IcRightWhite />
@@ -70,9 +75,7 @@ const TopSheet = (props: TopSheetProps) => {
       </S.OnBoardingBox>
       {userType !== USER_TYPE.DESIGNER ? (
         <S.StartButton type="button">
-          <S.StartButtonSpan>
-            {userType === USER_TYPE.GUEST ? '헤어 모델 지원하기 / 제안하기' : '헤어모델 지원하기'}
-          </S.StartButtonSpan>
+          <S.StartButtonSpan>{!userType ? '헤어 모델 지원하기 / 제안하기' : '헤어모델 지원하기'}</S.StartButtonSpan>
           <IcRightWhite />
         </S.StartButton>
       ) : null}

--- a/src/views/SignUpPage/components/EnterProfile.tsx
+++ b/src/views/SignUpPage/components/EnterProfile.tsx
@@ -72,7 +72,7 @@ const EnterProfile = ({ setIsInitialStep }: EnterProfileProps) => {
 export default EnterProfile;
 
 const EnterProfileLayout = styled.div`
-  height: 100dvh;
+  height: calc(100dvh - 8.6rem);
 
   background-color: ${({ theme }) => theme.colors.moddy_wt};
 `;

--- a/src/views/SignUpPage/components/PersonalInfo.tsx
+++ b/src/views/SignUpPage/components/PersonalInfo.tsx
@@ -7,9 +7,9 @@ import Button from '../../@common/components/Button';
 import Input from '../../@common/components/Input';
 import ProgressBar from '../../@common/components/ProgressBar';
 import ToastMessage from '../../@common/components/ToastMessage';
+import { USER_TYPE } from '../../@common/utils/userType';
 import { HELPER_MESSAGE, PLACE_HOLDER_MESSAGE, TOAST_MESSAGE } from '../constants/message';
 import { STEP, TOTAL_STEP } from '../constants/step';
-import { USER_TYPE } from '../constants/userType';
 
 import Field from './Field';
 

--- a/src/views/SignUpPage/components/PersonalInfo.tsx
+++ b/src/views/SignUpPage/components/PersonalInfo.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { useRecoilState } from 'recoil';
 import { styled } from 'styled-components';
 
 import { IcCheckBlue, IcInformation } from '../../@common/assets/icons';
@@ -11,19 +12,24 @@ import { STEP, TOTAL_STEP } from '../constants/step';
 import { USER_TYPE } from '../constants/userType';
 
 import Field from './Field';
+
+import { birthYearState, genderState, nameState } from '@/recoil/atoms/signUpState';
 interface PersonalInfoProp {
   setStep: React.Dispatch<React.SetStateAction<number>>;
 }
 
 const PersonalInfo = ({ setStep }: PersonalInfoProp) => {
-  const userType = USER_TYPE.DESIGNER;
-  const [selectedGender, setSelectedGender] = useState('');
-  const [birthYear, setBirthYear] = useState('');
+  const userType = USER_TYPE.MODEL;
+
+  const [name, setName] = useRecoilState(nameState);
+  const [birthYear, setBirthYear] = useRecoilState(birthYearState);
+  const [gender, setGender] = useRecoilState(genderState);
+
   const [verificationStatus, setVerificationStatus] = useState({
-    isNameVerified: false,
-    isBirthYearVerified: false,
-    isGenderVerified: false,
-    isAllVerified: false,
+    isNameVerified: name.verifyStatus,
+    isBirthYearVerified: birthYear.verifyStatus,
+    isGenderVerified: gender.verifyStatus,
+    isAllVerified: name.verifyStatus && birthYear.verifyStatus && gender.verifyStatus,
   });
   const [isToastOpen, setToastOpen] = useState<boolean>(false);
 
@@ -31,14 +37,18 @@ const PersonalInfo = ({ setStep }: PersonalInfoProp) => {
     const regex = /^[0-9\b]{0,4}$/;
 
     if (regex.test(e.target.value)) {
-      setBirthYear(e.target.value);
+      setBirthYear({ data: e.target.value, verifyStatus: verificationStatus.isBirthYearVerified });
       if (e.target.value.length === 4) {
         const regex = /^(19[0-9]{2}|200[0-9]|201[0-9]|202[0-4])$/;
         regex.test(e.target.value)
-          ? setVerificationStatus((prevState) => ({ ...prevState, isBirthYearVerified: true }))
-          : (setVerificationStatus((prevState) => ({ ...prevState, isBirthYearVerified: false })), setToastOpen(true));
+          ? (setVerificationStatus((prevState) => ({ ...prevState, isBirthYearVerified: true })),
+            setBirthYear({ data: e.target.value, verifyStatus: true }))
+          : (setVerificationStatus((prevState) => ({ ...prevState, isBirthYearVerified: false })),
+            setToastOpen(true),
+            setBirthYear({ data: e.target.value, verifyStatus: false }));
       } else {
         setVerificationStatus((prevState) => ({ ...prevState, isBirthYearVerified: false }));
+        setBirthYear({ data: e.target.value, verifyStatus: false });
       }
     }
   };
@@ -46,12 +56,13 @@ const PersonalInfo = ({ setStep }: PersonalInfoProp) => {
   const handleName = (value: string) => {
     if (value.length > 0 && value.length <= 10) {
       setVerificationStatus((prevState) => ({ ...prevState, isNameVerified: true }));
+      setName({ data: value, verifyStatus: true });
     }
   };
 
   const handleGender = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setSelectedGender(e.target.id);
     setVerificationStatus((prevState) => ({ ...prevState, isGenderVerified: true }));
+    setGender({ data: e.target.id, verifyStatus: true });
   };
 
   useEffect(() => {
@@ -88,7 +99,7 @@ const PersonalInfo = ({ setStep }: PersonalInfoProp) => {
               <S.InputBox>
                 <S.VerifyInput
                   placeholder={PLACE_HOLDER_MESSAGE.INPUT_BIRTH_YEAR}
-                  value={birthYear}
+                  value={birthYear.data}
                   onChange={handleBirthYear}
                 />
                 {verificationStatus.isBirthYearVerified ? <IcCheckBlue /> : null}
@@ -101,7 +112,7 @@ const PersonalInfo = ({ setStep }: PersonalInfoProp) => {
               type="radio"
               id="female"
               name="gender-type"
-              checked={selectedGender === 'female'}
+              checked={gender.data === 'female'}
               onChange={handleGender}
             />
             <S.GenderTypeLabel htmlFor="female">여성</S.GenderTypeLabel>
@@ -109,7 +120,7 @@ const PersonalInfo = ({ setStep }: PersonalInfoProp) => {
               type="radio"
               id="male"
               name="gender-type"
-              checked={selectedGender === 'male'}
+              checked={gender.data === 'male'}
               onChange={handleGender}
             />
             <S.GenderTypeLabel htmlFor="male">남성</S.GenderTypeLabel>

--- a/src/views/SignUpPage/components/PersonalInfo.tsx
+++ b/src/views/SignUpPage/components/PersonalInfo.tsx
@@ -86,7 +86,7 @@ const PersonalInfo = ({ setStep }: PersonalInfoProp) => {
       <S.PersonalInfoLayout>
         <S.FormBox>
           <Field name={userType === USER_TYPE.DESIGNER ? '디자이너명' : '이름'} isEssential={true} />
-          <Input placeholderText={PLACE_HOLDER_MESSAGE.INPUT_NAME} onChangeFn={handleName} />
+          <Input placeholderText={PLACE_HOLDER_MESSAGE.INPUT_NAME} onChangeFn={handleName} initialValue={name.data} />
           <S.HelperBox>
             <IcInformation />
             <S.HelperSpan>

--- a/src/views/SignUpPage/components/RegionItem.tsx
+++ b/src/views/SignUpPage/components/RegionItem.tsx
@@ -1,48 +1,64 @@
+import { useRecoilState } from 'recoil';
 import { styled } from 'styled-components';
 
 import { IcCheckboxBlue, IcCheckboxGrey } from '../../@common/assets/icons';
+
+import { preferRegionState } from '@/recoil/atoms/signUpState';
 interface RegionItemProps {
   region: string;
-  isCheckedList: boolean[];
   index: number;
-  setIsCheckedList: React.Dispatch<React.SetStateAction<boolean[]>>;
   regionList: string[];
 }
 
 const RegionItem = (props: RegionItemProps) => {
-  const { region, isCheckedList, index, setIsCheckedList, regionList } = props;
+  const { region, index, regionList } = props;
+  const [isCheckedList, setIsCheckedList] = useRecoilState(preferRegionState);
 
   const handleCheck = () => {
-    const selectedCount = isCheckedList.filter((value) => value === true).length;
+    const selectedCount = isCheckedList.data.filter((value) => value === true).length;
     // 전체선택을 누르면
     if (index === 0) {
-      setIsCheckedList(() => {
+      setIsCheckedList((prev) => {
         //전체가 이미 선택돼있다면 전체 취소하기/ 선택돼있지 않다면 전체 선택하고 나머지 다 취소
-        const updatedList = !isCheckedList[0]
-          ? [true, ...Array(regionList.length - 1)]
-          : [false, ...Array(regionList.length - 1)];
-        return updatedList;
+        const isAllSelected = prev.data[0];
+        const updatedData = isAllSelected
+          ? [false, ...Array(regionList.length - 1)]
+          : [true, ...Array(regionList.length - 1)];
+        return {
+          data: updatedData,
+          verifyStatus: prev.verifyStatus,
+        };
       });
     } else {
       //체크된게 3이상이면
       if (selectedCount >= 3) {
         //기존 체크된거 취소만 가능
-        if (isCheckedList[index]) {
+        if (isCheckedList.data[index]) {
           setIsCheckedList((prev) => {
-            const updatedList = [...prev];
+            const updatedList = [...prev.data];
             updatedList[index] = !updatedList[index];
-            isCheckedList[0] && (updatedList[0] = false);
-            return updatedList;
+            if (index !== 0 && updatedList[0]) {
+              updatedList[0] = false;
+            }
+            return {
+              data: updatedList,
+              verifyStatus: prev.verifyStatus,
+            };
           });
         }
       }
       //아니라면 체크하기/체크풀기 가능
       else {
         setIsCheckedList((prev) => {
-          const updatedList = [...prev];
+          const updatedList = [...prev.data];
           updatedList[index] = !updatedList[index];
-          isCheckedList[0] && (updatedList[0] = false);
-          return updatedList;
+          if (index !== 0 && updatedList[0]) {
+            updatedList[0] = false;
+          }
+          return {
+            data: updatedList,
+            verifyStatus: prev.verifyStatus,
+          };
         });
       }
     }
@@ -51,7 +67,7 @@ const RegionItem = (props: RegionItemProps) => {
   return (
     <S.CategoryItem>
       <button type="button" onClick={handleCheck}>
-        {isCheckedList[index] ? <IcCheckboxBlue /> : <IcCheckboxGrey />}
+        {isCheckedList.data && isCheckedList.data[index] ? <IcCheckboxBlue /> : <IcCheckboxGrey />}
       </button>
       <S.RegionSpan $ischecked={true.toString()}>{region}</S.RegionSpan>
     </S.CategoryItem>

--- a/src/views/SignUpPage/components/SelectPreferRegion.tsx
+++ b/src/views/SignUpPage/components/SelectPreferRegion.tsx
@@ -13,6 +13,7 @@ import Field from './Field';
 import RegionItem from './RegionItem';
 
 import { preferRegionState } from '@/recoil/atoms/signUpState';
+import Modal from '@/views/@common/components/Modal';
 
 const SelectPreferRegion = () => {
   const navigate = useNavigate();
@@ -20,6 +21,7 @@ const SelectPreferRegion = () => {
   const [isShowCategory, setIsShowCategory] = useState(false);
   const [isCheckedList, setIsCheckedList] = useRecoilState(preferRegionState);
   const [isShowBottomSheet, setIsShowBottomSheet] = useState(false);
+  const [isOpenModal, setOpenModal] = useState(false);
 
   const categoryRef = useRef<HTMLDivElement>(null);
   const bottomSheetRef = useRef<HTMLDivElement>(null);
@@ -115,10 +117,20 @@ const SelectPreferRegion = () => {
         text="완료"
         isFixed={true}
         onClickFn={() => {
-          navigate('/');
+          setOpenModal(true);
         }}
         disabled={!isCheckedList.verifyStatus}
       />
+      {isOpenModal && (
+        <Modal
+          title="이대로 가입하시겠어요?"
+          description="가입 후에는 수정이 어려워요"
+          leftBtnText="돌아가기"
+          rightBtnText="확인"
+          leftBtnFn={() => setOpenModal(false)}
+          rightBtnFn={() => navigate('/')}
+        />
+      )}
     </>
   );
 };

--- a/src/views/SignUpPage/components/SelectPreferRegion.tsx
+++ b/src/views/SignUpPage/components/SelectPreferRegion.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { useRecoilState } from 'recoil';
 import { styled } from 'styled-components';
 
@@ -14,6 +15,7 @@ import RegionItem from './RegionItem';
 import { preferRegionState } from '@/recoil/atoms/signUpState';
 
 const SelectPreferRegion = () => {
+  const navigate = useNavigate();
   const RegionList = ['전체', '관악구', '동작구', '강남구', '강동구', '강북구'];
   const [isShowCategory, setIsShowCategory] = useState(false);
   const [isCheckedList, setIsCheckedList] = useRecoilState(preferRegionState);
@@ -109,7 +111,14 @@ const SelectPreferRegion = () => {
           </S.SelectedListBox>
         </S.BottomSheetBox>
       </S.SelectPreferRegionLayout>
-      <Button text="완료" isFixed={true} onClickFn={() => {}} disabled={!isCheckedList.verifyStatus} />
+      <Button
+        text="완료"
+        isFixed={true}
+        onClickFn={() => {
+          navigate('/');
+        }}
+        disabled={!isCheckedList.verifyStatus}
+      />
     </>
   );
 };

--- a/src/views/SignUpPage/components/SelectUserType.tsx
+++ b/src/views/SignUpPage/components/SelectUserType.tsx
@@ -1,5 +1,5 @@
-import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { useRecoilState } from 'recoil';
 import { styled } from 'styled-components';
 
 import Button from '../../@common/components/Button';
@@ -7,6 +7,7 @@ import Header from '../../@common/components/Header';
 import { HELPER_MESSAGE } from '../constants/message';
 import { ON_BOARDING_TEXT } from '../constants/text';
 
+import { userTypeState } from '@/recoil/atoms/signUpState';
 import designerImg from '@images/img_designer.png';
 import modelImg from '@images/img_model.png';
 
@@ -16,12 +17,10 @@ interface SelectUserTypeProp {
 
 const SelectUserType = ({ setStep }: SelectUserTypeProp) => {
   const navigate = useNavigate();
-  const [userType, setUserType] = useState('');
-  const [isSelected, setIsSelected] = useState(false);
+  const [userType, setUserType] = useRecoilState(userTypeState);
 
   const handleUserType = (e: React.ChangeEvent<HTMLInputElement>) => {
     setUserType(e.target.id);
-    setIsSelected(true);
   };
 
   return (
@@ -38,7 +37,14 @@ const SelectUserType = ({ setStep }: SelectUserTypeProp) => {
         <S.OnBoardingSpan>{ON_BOARDING_TEXT.SELECT_USER_TYPE}</S.OnBoardingSpan>
         <S.HelperTextSpan>{HELPER_MESSAGE.USER_TYPE_CHANGE_UNAVAILABLE}</S.HelperTextSpan>
         <S.RadioBox>
-          <S.RadioInput type="radio" id="designer" name="user-type" value={userType} onChange={handleUserType} />
+          <S.RadioInput
+            type="radio"
+            id="designer"
+            name="user-type"
+            value={userType}
+            onChange={handleUserType}
+            checked={userType === 'designer'}
+          />
           <S.UserTypeBoxLabel htmlFor="designer">
             <S.ImageBox>
               <img src={designerImg} width="100%" alt="디자이너" />
@@ -50,7 +56,14 @@ const SelectUserType = ({ setStep }: SelectUserTypeProp) => {
               모델을 찾고 있어요
             </S.UserTypeInfoSpan>
           </S.UserTypeBoxLabel>
-          <S.RadioInput type="radio" id="model" name="user-type" value={userType} onChange={handleUserType} />
+          <S.RadioInput
+            type="radio"
+            id="model"
+            name="user-type"
+            value={userType}
+            onChange={handleUserType}
+            checked={userType === 'model'}
+          />
           <S.UserTypeBoxLabel htmlFor="model">
             <S.ImageBox>
               <img src={modelImg} width="100%" alt="모델" />
@@ -64,7 +77,7 @@ const SelectUserType = ({ setStep }: SelectUserTypeProp) => {
           </S.UserTypeBoxLabel>
         </S.RadioBox>
       </S.SelectUserTypeLayout>
-      <Button text="다음" isFixed={true} onClickFn={() => setStep(false)} disabled={!isSelected} />
+      <Button text="다음" isFixed={true} onClickFn={() => setStep(false)} disabled={!userType} />
     </>
   );
 };

--- a/src/views/SignUpPage/components/VerifyPhoneNumber.tsx
+++ b/src/views/SignUpPage/components/VerifyPhoneNumber.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { useRecoilState } from 'recoil';
 import { styled } from 'styled-components';
 
 import Button from '../../@common/components/Button';
@@ -10,6 +11,8 @@ import { USER_TYPE } from '../constants/userType';
 import useInterval from '../hooks/useInterval';
 
 import Field from './Field';
+
+import { phoneNumberState, verifyCodeState } from '@/recoil/atoms/signUpState';
 interface VerifyPhoneNumberProp {
   setStep: React.Dispatch<React.SetStateAction<number>>;
 }
@@ -17,14 +20,11 @@ interface VerifyPhoneNumberProp {
 const VerifyPhoneNumber = ({ setStep }: VerifyPhoneNumberProp) => {
   const userType = USER_TYPE.MODEL;
 
-  const [requestStatus, setRequestStatus] = useState(STATUS.NOT_AVAILABLE);
-  const [verifyStatus, setVerifyStatus] = useState(STATUS.NOT_AVAILABLE);
-  const [phoneNumber, setPhoneNumber] = useState('');
-  const [verifyNumber, setVerifyNumber] = useState('');
+  const [phoneNumber, setPhoneNumber] = useRecoilState(phoneNumberState);
+  const [verifyCode, setVerifyCode] = useRecoilState(verifyCodeState);
   const [seconds, setSeconds] = useState(180);
   const [isVerifying, setIsVerifying] = useState(false);
   const [isRequested, setIsRequested] = useState(false);
-  const [isAllVerified, SetIsAllVerified] = useState(false);
 
   useInterval(() => {
     isVerifying && seconds > 0 && setSeconds((prev) => prev - 1);
@@ -39,36 +39,48 @@ const VerifyPhoneNumber = ({ setStep }: VerifyPhoneNumberProp) => {
   const handlePhoneNumber = (e: React.ChangeEvent<HTMLInputElement>) => {
     const regex = /^[0-9\b -]{0,13}$/;
     if (regex.test(e.target.value)) {
-      setPhoneNumber(e.target.value);
-      e.target.value.length === 11 ? setRequestStatus(STATUS.AVAILABLE) : setRequestStatus(STATUS.NOT_AVAILABLE);
+      setPhoneNumber({
+        data: e.target.value,
+        status: e.target.value.length === 11 ? STATUS.AVAILABLE : STATUS.NOT_AVAILABLE,
+      });
     }
   };
 
-  const handleVerifyNumber = (e: React.ChangeEvent<HTMLInputElement>) => {
+  const handleVerifyCode = (e: React.ChangeEvent<HTMLInputElement>) => {
     const regex = /^[0-9\b]{0,6}$/;
     if (regex.test(e.target.value)) {
-      setVerifyNumber(e.target.value);
-      e.target.value.length === 6 ? setVerifyStatus(STATUS.AVAILABLE) : setVerifyStatus(STATUS.NOT_AVAILABLE);
+      setVerifyCode({
+        data: e.target.value,
+        status: e.target.value.length === 6 ? STATUS.AVAILABLE : STATUS.NOT_AVAILABLE,
+      });
     }
   };
 
   const handleRequestVerify = () => {
-    if (requestStatus !== STATUS.DONE) {
-      if (requestStatus === STATUS.RE_AVALILABLE) {
+    if (phoneNumber.status !== STATUS.DONE) {
+      if (phoneNumber.status === STATUS.RE_AVALILABLE) {
         setSeconds(180);
       }
       setIsRequested(true);
       setIsVerifying(true);
-      phoneNumber.replace('-', '');
-      setRequestStatus(STATUS.RE_AVALILABLE);
+      phoneNumber.data.replace('-', '');
+      setPhoneNumber({
+        data: phoneNumber.data,
+        status: STATUS.RE_AVALILABLE,
+      });
     }
   };
 
   const handleConfirmVerify = () => {
     if (seconds > 0) {
-      setRequestStatus(STATUS.DONE);
-      setVerifyStatus(STATUS.VERIFIED);
-      SetIsAllVerified(true);
+      setPhoneNumber({
+        data: phoneNumber.data,
+        status: STATUS.DONE,
+      });
+      setVerifyCode({
+        data: verifyCode.data,
+        status: STATUS.VERIFIED,
+      });
     }
   };
 
@@ -88,23 +100,25 @@ const VerifyPhoneNumber = ({ setStep }: VerifyPhoneNumberProp) => {
         <S.InputBox>
           <S.Input
             placeholder={PLACE_HOLDER_MESSAGE.INPUT_PHONE_NUMBER}
-            value={phoneNumber.replace(/-/g, '').replace(/(\d{3})(\d{4})(\d{4})/, '$1-$2-$3')}
+            value={phoneNumber.data.replace(/-/g, '').replace(/(\d{3})(\d{4})(\d{4})/, '$1-$2-$3')}
             onChange={handlePhoneNumber}
           />
-          <S.RequestButton $status={requestStatus} onClick={handleRequestVerify}>
-            {requestStatus !== STATUS.RE_AVALILABLE && requestStatus !== STATUS.DONE ? '인증 요청' : '재요청'}
+          <S.RequestButton $status={phoneNumber.status} onClick={handleRequestVerify}>
+            {phoneNumber.status !== STATUS.RE_AVALILABLE && phoneNumber.status !== STATUS.DONE ? '인증 요청' : '재요청'}
           </S.RequestButton>
         </S.InputBox>
         {isRequested && (
           <S.InputBox>
             <S.Input
               placeholder={PLACE_HOLDER_MESSAGE.INPUT_VERIFY_CODE}
-              value={verifyNumber}
-              onChange={handleVerifyNumber}
+              value={verifyCode.data}
+              onChange={handleVerifyCode}
             />
-            <S.CountDownSpan>{!isVerifying || verifyStatus === STATUS.VERIFIED ? null : formatTime()}</S.CountDownSpan>
-            <S.RequestButton $status={verifyStatus} onClick={handleConfirmVerify}>
-              {verifyStatus !== STATUS.VERIFIED ? '확인' : '인증 완료'}
+            <S.CountDownSpan>
+              {!isVerifying || verifyCode.status === STATUS.VERIFIED ? null : formatTime()}
+            </S.CountDownSpan>
+            <S.RequestButton $status={verifyCode.status} onClick={handleConfirmVerify}>
+              {verifyCode.status !== STATUS.VERIFIED ? '확인' : '인증 완료'}
             </S.RequestButton>
           </S.InputBox>
         )}
@@ -113,7 +127,7 @@ const VerifyPhoneNumber = ({ setStep }: VerifyPhoneNumberProp) => {
         text="다음"
         isFixed={true}
         onClickFn={() => setStep(STEP.MODEL.PREFER_REGION)}
-        disabled={!isAllVerified}
+        disabled={verifyCode.status !== STATUS.VERIFIED}
       />
     </>
   );

--- a/src/views/SignUpPage/components/VerifyPhoneNumber.tsx
+++ b/src/views/SignUpPage/components/VerifyPhoneNumber.tsx
@@ -4,10 +4,10 @@ import { styled } from 'styled-components';
 
 import Button from '../../@common/components/Button';
 import ProgressBar from '../../@common/components/ProgressBar';
+import { USER_TYPE } from '../../@common/utils/userType';
 import { HELPER_MESSAGE, PLACE_HOLDER_MESSAGE } from '../constants/message';
 import { STATUS } from '../constants/requestStatus';
 import { STEP, TOTAL_STEP } from '../constants/step';
-import { USER_TYPE } from '../constants/userType';
 import useInterval from '../hooks/useInterval';
 
 import Field from './Field';

--- a/src/views/SignUpPage/constants/userType.ts
+++ b/src/views/SignUpPage/constants/userType.ts
@@ -1,4 +1,0 @@
-export const USER_TYPE = {
-  DESIGNER: 0,
-  MODEL: 1,
-};

--- a/yarn.lock
+++ b/yarn.lock
@@ -2152,6 +2152,11 @@ graphemer@^1.4.0:
   resolved "https://registry.yarnpkg.com/graphemer/-/graphemer-1.4.0.tgz#fb2f1d55e0e3a1849aeffc90c4fa0dd53a0e66c6"
   integrity sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==
 
+hamt_plus@1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/hamt_plus/-/hamt_plus-1.0.2.tgz#e21c252968c7e33b20f6a1b094cd85787a265601"
+  integrity sha512-t2JXKaehnMb9paaYA7J0BX8QQAY8lwfQ9Gjf4pg/mk4krt+cmwmU652HOoWonf+7+EQV97ARPMhhVgU1ra2GhA==
+
 has-bigints@^1.0.1, has-bigints@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/has-bigints/-/has-bigints-1.0.2.tgz#0871bd3e3d51626f6ca0966668ba35d5602d6eaa"
@@ -3163,6 +3168,13 @@ react@^18.2.0:
   integrity sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==
   dependencies:
     loose-envify "^1.1.0"
+
+recoil@^0.7.7:
+  version "0.7.7"
+  resolved "https://registry.yarnpkg.com/recoil/-/recoil-0.7.7.tgz#c5f2c843224384c9c09e4a62c060fb4c1454dc8e"
+  integrity sha512-8Og5KPQW9LwC577Vc7Ug2P0vQshkv1y3zG3tSSkWMqkWSwHmE+by06L8JtnGocjW6gcCvfwB3YtrJG6/tWivNQ==
+  dependencies:
+    hamt_plus "1.0.2"
 
 reflect.getprototypeof@^1.0.4:
   version "1.0.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3169,6 +3169,11 @@ react@^18.2.0:
   dependencies:
     loose-envify "^1.1.0"
 
+recoil-persist@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/recoil-persist/-/recoil-persist-5.1.0.tgz#c4232fe04f2e4b6afcc815baff56f2521f6dcde1"
+  integrity sha512-sew4k3uBVJjRWKCSFuBw07Y1p1pBOb0UxLJPxn4G2bX/9xNj+r2xlqYy/BRfyofR/ANfqBU04MIvulppU4ZC0w==
+
 recoil@^0.7.7:
   version "0.7.7"
   resolved "https://registry.yarnpkg.com/recoil/-/recoil-0.7.7.tgz#c5f2c843224384c9c09e4a62c060fb4c1454dc8e"


### PR DESCRIPTION
<!-- PR의 제목은 "[페이지명] 구현내용 " 으로, 연결되는 이슈 제목과 동일하게 가져가시면 됩니다! -->

## ▶️ Related Issue

close #126 

## ✨ DONE Task

- [x] 회원가입 뷰 input 값 유지
- [x] 검증 상태 유지
- [x] input 클릭 시 자동 줌 막기
- [x] 회원 가입 후 메인 페이지로 이동

<br />

## 💎 PR Point

컴포넌트 이동 시에 너무 많은 데이터를 가지고 다녀야해서 `recoil`을 도입하게 되었습니다!
유저타입(디자이너/모델) 은 `recoil-persist`로 local storage에 저장하여 main이동 시 판별하여 해당 컴포넌트를 뿌려주도록 하였습니다.
```javascript
const { persistAtom } = recoilPersist();

export const userTypeState = atom({
  key: 'userType',
  default: null,
  effects_UNSTABLE: [persistAtom],
});

const MainPage = () => {
  const userType = useRecoilValue(userTypeState);
  const applyType = APPLY_TYPE.NOT_YET;

  return (
    <MainPageLayout>
      ...
      {!userType ? <Contents /> : <ReceivedOffer applyType={applyType} />}
    </MainPageLayout>
  );
};
```

아직 recoil에 익숙하지 않아서 구현 방식에 대한 조언도 있으면 부탁드려용
```javascript
export const nameState = atom<inputDataType>({
  key: 'name',
  default: {
    data: '',
    verifyStatus: false,
  },
});

export const birthYearState = atom<inputDataType>({
  key: 'birthYear',
  default: {
    data: '',
    verifyStatus: false,
  },
});
```

<br />

## 🖼️ Screenshot

https://github.com/TEAM-MODDY/moddy-web/assets/46593078/24203116-3c4c-47c5-b304-5ae97a4bafdb


