### PR TITLE
[LoginPage] 로그인 절차에서 Recoil 도입 

### DIFF
--- a/src/pages/AgreementPage.tsx
+++ b/src/pages/AgreementPage.tsx
@@ -1,15 +1,19 @@
 import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { useRecoilState } from 'recoil';
 
 import Button from '../views/@common/components/Button';
 import Header from '../views/@common/components/Header';
 import AgreementList from '../views/AgreementPage/components/AgreementList';
 
+import { agreementState } from '@/recoil/atoms/agreementState';
+
 const AgreementPage = () => {
-  const [isChecked, setChecked] = useState<boolean[]>(new Array(4).fill(false));
+  const [isChecked, setChecked] = useRecoilState<boolean[]>(agreementState);
   const navigate = useNavigate();
 
   useEffect(() => {
+    console.log(isChecked);
     const tempChecked = [...isChecked];
     tempChecked[0] = isChecked[1] && isChecked[2] && isChecked[3];
     setChecked(tempChecked);

--- a/src/pages/AgreementPage.tsx
+++ b/src/pages/AgreementPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useRecoilState } from 'recoil';
 
@@ -13,7 +13,6 @@ const AgreementPage = () => {
   const navigate = useNavigate();
 
   useEffect(() => {
-    console.log(isChecked);
     const tempChecked = [...isChecked];
     tempChecked[0] = isChecked[1] && isChecked[2] && isChecked[3];
     setChecked(tempChecked);
@@ -22,7 +21,7 @@ const AgreementPage = () => {
   return (
     <div>
       <Header title="이용약관" isBackBtnExist backFn={() => navigate(-1)} />
-      <AgreementList isChecked={isChecked} setChecked={setChecked} />
+      <AgreementList />
       <Button text="다음" isFixed onClickFn={() => navigate('/sign-up')} disabled={!isChecked[1] || !isChecked[2]} />
     </div>
   );

--- a/src/recoil/atoms/agreementState.ts
+++ b/src/recoil/atoms/agreementState.ts
@@ -1,0 +1,6 @@
+import { atom } from 'recoil';
+
+export const agreementState = atom<boolean[]>({
+  key: 'agreementArray',
+  default: new Array(4).fill(false),
+});

--- a/src/recoil/atoms/kakaoCodeState.ts
+++ b/src/recoil/atoms/kakaoCodeState.ts
@@ -1,0 +1,13 @@
+import { atom } from 'recoil';
+import { recoilPersist } from 'recoil-persist';
+
+const { persistAtom } = recoilPersist({
+  key: '카카오 인가코드',
+  storage: sessionStorage,
+});
+
+export const kakaoCodeState = atom({
+  key: 'kakaoCode',
+  default: '',
+  effects_UNSTABLE: [persistAtom],
+});

--- a/src/recoil/atoms/signUpState.ts
+++ b/src/recoil/atoms/signUpState.ts
@@ -26,8 +26,8 @@ export const userTypeState = atom({
   effects_UNSTABLE: [persistAtom],
 });
 
-export const agreementState = atom<boolean>({
-  key: 'agreement',
+export const marketingState = atom<boolean>({
+  key: 'marketing',
   default: false,
 });
 

--- a/src/recoil/atoms/signUpState.ts
+++ b/src/recoil/atoms/signUpState.ts
@@ -2,10 +2,22 @@ import { atom } from 'recoil';
 import { recoilPersist } from 'recoil-persist';
 
 import { STATUS } from '@/views/SignUpPage/constants/requestStatus';
+
 export interface inputDataType {
   data: string;
   verifyStatus: boolean;
 }
+
+interface verificationDataType {
+  data: string;
+  status: number;
+}
+
+export interface preferRegionDataType {
+  data: boolean[];
+  verifyStatus: boolean;
+}
+
 const { persistAtom } = recoilPersist();
 
 export const userTypeState = atom({
@@ -43,11 +55,6 @@ export const genderState = atom<inputDataType>({
   },
 });
 
-interface verificationDataType {
-  data: string;
-  status: number;
-}
-
 export const phoneNumberState = atom<verificationDataType>({
   key: 'phoneNumber',
   default: {
@@ -63,11 +70,6 @@ export const verifyCodeState = atom<verificationDataType>({
     status: STATUS.NOT_AVAILABLE,
   },
 });
-
-export interface preferRegionDataType {
-  data: boolean[];
-  verifyStatus: boolean;
-}
 
 export const preferRegionState = atom<preferRegionDataType>({
   key: 'preferRegion',

--- a/src/recoil/atoms/signUpState.ts
+++ b/src/recoil/atoms/signUpState.ts
@@ -18,7 +18,10 @@ export interface preferRegionDataType {
   verifyStatus: boolean;
 }
 
-const { persistAtom } = recoilPersist();
+const { persistAtom } = recoilPersist({
+  key: '사용자 타입',
+  storage: sessionStorage,
+});
 
 export const userTypeState = atom({
   key: 'userType',

--- a/src/views/AgreementPage/components/AgreementList.tsx
+++ b/src/views/AgreementPage/components/AgreementList.tsx
@@ -3,15 +3,12 @@ import styled from 'styled-components';
 
 import AgreementItem from './AgreementItem';
 
-import { agreementState } from '@/recoil/atoms/signUpState';
+import { agreementState } from '@/recoil/atoms/agreementState';
+import { marketingState } from '@/recoil/atoms/signUpState';
 
-interface AgreementListProps {
-  isChecked: boolean[];
-  setChecked: React.Dispatch<React.SetStateAction<boolean[]>>;
-}
-
-const AgreementList = ({ isChecked, setChecked }: AgreementListProps) => {
-  const [, setMarketingAgree] = useRecoilState(agreementState);
+const AgreementList = () => {
+  const [, setMarketingAgree] = useRecoilState(marketingState);
+  const [isChecked, setChecked] = useRecoilState<boolean[]>(agreementState);
 
   const handleCheck = (idx: number) => {
     if (idx === 0) {

--- a/src/views/LoginPage/hooks/usePostLogin.ts
+++ b/src/views/LoginPage/hooks/usePostLogin.ts
@@ -23,7 +23,7 @@ const usePostLogin = () => {
       })
       .catch((err: loginErrorProps) => {
         if (err.response.data.code === 404) {
-          navigate('/sign-up');
+          navigate('/agreement');
         } else {
           navigate('/error');
         }

--- a/src/views/LoginPage/hooks/usePostLogin.ts
+++ b/src/views/LoginPage/hooks/usePostLogin.ts
@@ -1,13 +1,16 @@
 import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { useSetRecoilState } from 'recoil';
 
 import { loginErrorProps, loginResProps } from './type';
 
+import { kakaoCodeState } from '@/recoil/atoms/kakaoCodeState';
 import api from '@/views/@common/hooks/api';
 
 const usePostLogin = () => {
   const KAKAO_CODE = new URL(window.location.href).searchParams.get('code');
   const navigate = useNavigate();
+  const setKakaoCode = useSetRecoilState(kakaoCodeState);
 
   useEffect(() => {
     api
@@ -23,6 +26,7 @@ const usePostLogin = () => {
       })
       .catch((err: loginErrorProps) => {
         if (err.response.data.code === 404) {
+          setKakaoCode(KAKAO_CODE);
           navigate('/agreement');
         } else {
           navigate('/error');

--- a/src/views/SignUpPage/hooks/useModelSignUp.ts
+++ b/src/views/SignUpPage/hooks/useModelSignUp.ts
@@ -6,7 +6,7 @@ import { useRecoilValue } from 'recoil';
 import { ModelSignUpRequest } from './type';
 
 import {
-  agreementState,
+  marketingState,
   birthYearState,
   genderState,
   nameState,
@@ -26,7 +26,7 @@ const useModelSignUp = () => {
   const gender = useRecoilValue(genderState);
   const phoneNumber = useRecoilValue(phoneNumberState);
   const preferRegions = useRecoilValue(preferRegionState);
-  const isMarketingAgree = useRecoilValue(agreementState);
+  const isMarketingAgree = useRecoilValue(marketingState);
 
   const preferRegion = preferRegions.data.map((value, index) => (value ? index : -1)).filter((index) => index !== -1);
 


### PR DESCRIPTION
<!-- PR의 제목은 "[페이지명] 구현내용 " 으로, 연결되는 이슈 제목과 동일하게 가져가시면 됩니다! -->

## ▶️ Related Issue

close #166 

## ✨ DONE Task

- [x] recoil-persist로 인가코드 관리
- [x] 경우에 따라 navigation 분기
- [x] agreementPage recoil로 체크여부 관리
- [x] userTypeState localStorage -> sessionStorage로 변경 

<br />

## 💎 PR Point
### Recoil-Persist로 인가코드 관리 
```tsx
const { persistAtom } = recoilPersist({
  key: '카카오 인가코드',
  storage: sessionStorage,
});

export const kakaoCodeState = atom({
  key: 'kakaoCode',
  default: '',
  effects_UNSTABLE: [persistAtom],
});
```
- 📣`kakaoCodeState`**로 인가코드 가져다가 사용하시면 됩니다!** 
- 로그인할 때마다 일회성으로 사용되는 코드이기 때문에 localStorage가 아닌 sessionStorage로 저장합니다. 

```tsx
.catch((err: loginErrorProps) => {
  if (err.response.data.code === 404) {
    setKakaoCode(KAKAO_CODE);
    navigate('/agreement');
  } else {
    navigate('/error');
  }
```
- 404에러일 경우 존재하지 않는 유저이기 때문에 회원가입 플로우로 넘어가게 됩니다. 
- 이때 이용약관 동의 페이지로 이동함과 동시에 인가코드를 sessionStorage에 저장해줍니다. 

### userTypeState sessionStorage로 변경 
해놓았습니다 
```tsx
const { persistAtom } = recoilPersist({
  key: '사용자 타입',
  storage: sessionStorage,
});
```