### PR TITLE
[SignUpPage] 가입 프로세스 끝나고 유저 타입 스토리지에 저장

### DIFF
--- a/src/recoil/atoms/signUpState.ts
+++ b/src/recoil/atoms/signUpState.ts
@@ -25,8 +25,13 @@ const { persistAtom } = recoilPersist({
 
 export const userTypeState = atom({
   key: 'userType',
-  default: null,
+  default: '',
   effects_UNSTABLE: [persistAtom],
+});
+
+export const tempUserTypeState = atom<string>({
+  key: 'tempUserType',
+  default: '',
 });
 
 export const marketingState = atom<boolean>({

--- a/src/views/SignUpPage/components/UserType.tsx
+++ b/src/views/SignUpPage/components/UserType.tsx
@@ -7,7 +7,7 @@ import Header from '../../@common/components/Header';
 import { HELPER_MESSAGE } from '../constants/message';
 import { ON_BOARDING_TEXT } from '../constants/text';
 
-import { userTypeState } from '@/recoil/atoms/signUpState';
+import { tempUserTypeState, userTypeState } from '@/recoil/atoms/signUpState';
 import designerImg from '@images/img_designer.png';
 import modelImg from '@images/img_model.png';
 
@@ -17,7 +17,7 @@ interface SelectUserTypeProp {
 
 const UserType = ({ setStep }: SelectUserTypeProp) => {
   const navigate = useNavigate();
-  const [userType, setUserType] = useRecoilState(userTypeState);
+  const [userType, setUserType] = useRecoilState(tempUserTypeState);
 
   const handleUserType = (e: React.ChangeEvent<HTMLInputElement>) => {
     setUserType(e.target.id);

--- a/src/views/SignUpPage/hooks/useModelSignUp.ts
+++ b/src/views/SignUpPage/hooks/useModelSignUp.ts
@@ -1,7 +1,7 @@
 import { AxiosError } from 'axios';
 import { useEffect, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { useRecoilValue } from 'recoil';
+import { useRecoilValue, useSetRecoilState } from 'recoil';
 
 import { ModelSignUpRequest } from './type';
 
@@ -12,6 +12,8 @@ import {
   nameState,
   phoneNumberState,
   preferRegionState,
+  tempUserTypeState,
+  userTypeState,
 } from '@/recoil/atoms/signUpState';
 import api from '@/views/@common/hooks/api';
 
@@ -21,6 +23,8 @@ const useModelSignUp = () => {
   const [isLoading, setLoading] = useState(true);
   const [isError, setError] = useState<AxiosError>();
 
+  const tempUserType = useRecoilValue(tempUserTypeState);
+  const setSessionUserType = useSetRecoilState(userTypeState);
   const name = useRecoilValue(nameState);
   const birthYear = useRecoilValue(birthYearState);
   const gender = useRecoilValue(genderState);
@@ -46,6 +50,7 @@ const useModelSignUp = () => {
         },
       });
       console.log(data);
+      setSessionUserType(tempUserType);
       navigate('/');
     } catch (err) {
       if (err instanceof AxiosError) setError(err);


### PR DESCRIPTION
<!-- PR의 제목은 "[페이지명] 구현내용 " 으로, 연결되는 이슈 제목과 동일하게 가져가시면 됩니다! -->

## ▶️ Related Issue

close #174 

## ✨ DONE Task

- [x] 가입 프로세스 끝나고 유저 타입 스토리지에 저장

<br />

## 💎 PR Point

디자이너/모델 선택 후 회원가입 중 메인으로 넘어가게 되면 해당 메인으로 넘어가져서 임시저장용 / 스토리지 저장용 atom을 분리하여 관리하여 해결하였습니다

