### PR TITLE
[OfferInfoPage] useGetAgree API 구현 

### DIFF
--- a/src/views/OfferInfoPage/components/ButtonBox.tsx
+++ b/src/views/OfferInfoPage/components/ButtonBox.tsx
@@ -2,17 +2,16 @@ import { styled } from 'styled-components';
 
 import Button from '../../@common/components/Button';
 import { IcDownload, IcLink } from '../assets/icons';
-import { CHECK_OFFER_DATA } from '../constants/CHECK_OFFER_DATA';
 
 interface ButtonBoxProps {
   onClick: () => void;
+  kakaoUrl: string;
 }
 
-const ButtonBox = ({ onClick }: ButtonBoxProps) => {
+const ButtonBox = ({ onClick, kakaoUrl }: ButtonBoxProps) => {
   //오픈채팅방 연결
-  const OpenChatLink = CHECK_OFFER_DATA.data.kakaoUrl;
   const handleClickChat = () => {
-    window.open(OpenChatLink, '_blank');
+    window.open(kakaoUrl, '_blank');
   };
 
   return (

--- a/src/views/OfferInfoPage/components/CheckOfferPage.tsx
+++ b/src/views/OfferInfoPage/components/CheckOfferPage.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { styled } from 'styled-components';
 
 import Header from '../../@common/components/Header';
+import useGetAgree from '../hooks/useGetAgree';
 
 import ButtonBox from './ButtonBox';
 import ImgBox from './ImgBox';
@@ -27,30 +28,36 @@ const CheckOfferPage = () => {
     setIsModal(true);
   };
 
-  return (
-    <>
-      <ScrollToTop />
-      <ImgModal isModal={isModal} onClose={() => setIsModal(false)} />
-      <Header
-        title=""
-        isBackBtnExist={true}
-        isCloseBtnExist={true}
-        backFn={handleClickBack}
-        closeFn={handleClickClose}
-      />
-      <S.CheckOfferLayout>
-        <ImgBox />
-        <S.MainText>
-          디자이너의 오픈채팅방에 입장해
-          <br /> 제안서를 보내주세요
-        </S.MainText>
-        <S.SubTitle>지원 내역 확인 & 1:1 오픈 채팅</S.SubTitle>
-        <ButtonBox onClick={handleModalOpen} />
+  const { data, isLoading, isError } = useGetAgree(1);
 
-        <S.SubTitle>연결 예정 디자이너</S.SubTitle>
-        <ProfileWrapperBox />
-      </S.CheckOfferLayout>
-    </>
+  return (
+    !isLoading &&
+    !isError &&
+    data && (
+      <>
+        <ScrollToTop />
+        <ImgModal isModal={isModal} onClose={() => setIsModal(false)} imgUrl={data.applicationImgUrl} />
+        <Header
+          title=""
+          isBackBtnExist={true}
+          isCloseBtnExist={true}
+          backFn={handleClickBack}
+          closeFn={handleClickClose}
+        />
+        <S.CheckOfferLayout>
+          <ImgBox />
+          <S.MainText>
+            디자이너의 오픈채팅방에 입장해
+            <br /> 제안서를 보내주세요
+          </S.MainText>
+          <S.SubTitle>지원 내역 확인 & 1:1 오픈 채팅</S.SubTitle>
+          <ButtonBox onClick={handleModalOpen} kakaoUrl={data.kakaoUrl} />
+
+          <S.SubTitle>연결 예정 디자이너</S.SubTitle>
+          <ProfileWrapperBox designerInfo={data.designerInfo} />
+        </S.CheckOfferLayout>
+      </>
+    )
   );
 };
 

--- a/src/views/OfferInfoPage/components/CheckOfferPage.tsx
+++ b/src/views/OfferInfoPage/components/CheckOfferPage.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { styled } from 'styled-components';
 
 import Header from '../../@common/components/Header';
@@ -28,7 +28,8 @@ const CheckOfferPage = () => {
     setIsModal(true);
   };
 
-  const { data, isLoading, isError } = useGetAgree(1);
+  const location = useLocation();
+  const { data, isLoading, isError } = useGetAgree(location.state.offerId);
 
   return (
     !isLoading &&

--- a/src/views/OfferInfoPage/components/DirectionModal.tsx
+++ b/src/views/OfferInfoPage/components/DirectionModal.tsx
@@ -12,8 +12,15 @@ interface DirectionModalProps {
 const DirectionModal = ({ isModal, onClose }: DirectionModalProps) => {
   const navigate = useNavigate();
 
+  // 임시 offerId. 추후 OfferInfoPage에서 fetch해온 데이터에서 id를 추출하여 해당 Modal로 내려줘야함.
+  const TEST_OFFER_ID = 1;
+
   const handleOnClickContinue = () => {
-    navigate('/offer-info/check-offer');
+    navigate('/offer-info/check-offer', {
+      state: {
+        offerId: TEST_OFFER_ID,
+      },
+    });
   };
 
   const handleModalClose = () => {

--- a/src/views/OfferInfoPage/components/ImgModal.tsx
+++ b/src/views/OfferInfoPage/components/ImgModal.tsx
@@ -3,16 +3,16 @@ import { styled } from 'styled-components';
 
 import { IcBookmark } from '../assets/icons';
 import ImgApplicationLogo from '../assets/images/img_applicationlogo.png';
-import { CHECK_OFFER_DATA } from '../constants/CHECK_OFFER_DATA';
 
 import { IcCloseBlack } from '@/views/@common/assets/icons';
 
 interface ImgModalProps {
   isModal?: boolean;
   onClose: () => void;
+  imgUrl: string;
 }
 
-const ImgModal = ({ isModal, onClose }: ImgModalProps) => {
+const ImgModal = ({ isModal, onClose, imgUrl }: ImgModalProps) => {
   //모달 닫기
   const handleModalClose = () => {
     onClose();
@@ -22,7 +22,7 @@ const ImgModal = ({ isModal, onClose }: ImgModalProps) => {
 
   const fetchImage = async () => {
     try {
-      const response = await fetch(CHECK_OFFER_DATA.data.applicationImgUrl);
+      const response = await fetch(imgUrl);
       if (!response.ok) {
         throw new Error(`이미지 저장 실패`);
       }
@@ -45,7 +45,7 @@ const ImgModal = ({ isModal, onClose }: ImgModalProps) => {
             <S.CloseBtnBox onClick={handleModalClose}>
               <IcCloseBlack />
             </S.CloseBtnBox>
-            <S.MyRecordImg src={CHECK_OFFER_DATA.data.applicationImgUrl} />
+            <S.MyRecordImg src={imgUrl} />
             <S.LogoBox src={ImgApplicationLogo} />
             <S.SaveBtn
               onClick={() => {

--- a/src/views/OfferInfoPage/components/ProfileWrapperBox.tsx
+++ b/src/views/OfferInfoPage/components/ProfileWrapperBox.tsx
@@ -1,18 +1,19 @@
 import { styled } from 'styled-components';
 
-import { CHECK_OFFER_DATA } from '../constants/CHECK_OFFER_DATA';
+import { AgreeDesignerInfoProps } from '../hooks/type';
 
-const ProfileWrapperBox = () => {
+const ProfileWrapperBox = ({ designerInfo }: { designerInfo: AgreeDesignerInfoProps }) => {
+  const { imgUrl, shopName, name, introduction }: AgreeDesignerInfoProps = designerInfo;
   return (
     <S.ProfileWrapperLayout>
       <S.ProfileBox>
-        <img src={CHECK_OFFER_DATA.data.designerInfo.imgUrl} alt="디자이너 프로필 이미지" />
+        <img src={imgUrl} alt="디자이너 프로필 이미지" />
         <div>
-          <h3>모디 헤어 강남점</h3>
-          <h2>너무 졸려 디자이너</h2>
+          <h3>{shopName}</h3>
+          <h2>{name}</h2>
         </div>
       </S.ProfileBox>
-      <p>{CHECK_OFFER_DATA.data.designerInfo.introduction}</p>
+      <p>{introduction}</p>
     </S.ProfileWrapperLayout>
   );
 };

--- a/src/views/OfferInfoPage/hooks/type.ts
+++ b/src/views/OfferInfoPage/hooks/type.ts
@@ -30,7 +30,7 @@ export interface UseGetOfferModelRes {
   data: UseGetOfferModelProps;
 }
 
-interface AgreeDesignerInfoProps {
+export interface AgreeDesignerInfoProps {
   imgUrl: string;
   shopName: string;
   name: string;

--- a/src/views/OfferInfoPage/hooks/type.ts
+++ b/src/views/OfferInfoPage/hooks/type.ts
@@ -29,3 +29,22 @@ export interface UseGetOfferModelRes {
   message: string;
   data: UseGetOfferModelProps;
 }
+
+interface AgreeDesignerInfoProps {
+  imgUrl: string;
+  shopName: string;
+  name: string;
+  introduction: string;
+}
+
+export interface UseGetAgreeProps {
+  applicationImgUrl: string;
+  kakaoUrl: string;
+  designerInfo: AgreeDesignerInfoProps;
+}
+
+export interface UseGetAgreeRes {
+  code: number;
+  message: string;
+  data: UseGetAgreeProps;
+}

--- a/src/views/OfferInfoPage/hooks/useGetAgree.ts
+++ b/src/views/OfferInfoPage/hooks/useGetAgree.ts
@@ -1,0 +1,40 @@
+import { AxiosError } from 'axios';
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+import { UseGetAgreeProps } from './type';
+
+import api from '@/views/@common/hooks/api';
+
+const useGetAgree = (offerId: number) => {
+  const navigate = useNavigate();
+  const [data, setData] = useState<UseGetAgreeProps>();
+  const [isLoading, setLoading] = useState(true);
+  const [isError, setError] = useState<AxiosError>();
+
+  const fetchData = async () => {
+    try {
+      const response = await api.get(`/model/${offerId}/agree`, {
+        headers: {
+          Authorization: 'Bearer ~',
+        },
+      });
+      setData(response.data.data);
+    } catch (err) {
+      if (err instanceof AxiosError) setError(err);
+      else {
+        console.log(err);
+      }
+      navigate('/error');
+    }
+    setLoading(false);
+  };
+
+  useEffect(() => {
+    fetchData();
+  }, []);
+
+  return { data, isLoading, isError };
+};
+
+export default useGetAgree;


### PR DESCRIPTION
<!-- PR의 제목은 "[페이지명] 구현내용 " 으로, 연결되는 이슈 제목과 동일하게 가져가시면 됩니다! -->

## ▶️ Related Issue

close #194 

## ✨ DONE Task

- [x] useGetAgree API hook 구현 
- [x] CheckOfferPage와 연결 
- [x] DirectionModal -> CheckOfferPage로 offerId 전달  

<br />

## 💎 PR Point
### params인 offerId 전달받기 
offerId는 OfferInfoPage의 GET 통신에서 받을 수 있습니다 
해당 데이터를 useGetAgree에 보내주기까지의 경로는 아래와 같습니다. 
`OfferInfoPage -> DirectionModal -> CheckOfferPage -> useGetAgree`
- 따라서 `OfferInfoPage -> DirectionModal` 은 props drilling으로 
- `DirectionModal -> CheckOfferPage`는 navigation시 state로 
- `CheckOfferPage -> useGetAgree`는 함수 인자로 전달해줍니다. 

### 데이터 구조 
- CheckOfferPage에서 useGetAgree 호출 및 데이터 페칭 
  ```json
  // 형태 
  "data": {
        "applicationImgUrl" : "http://지원내역 캡쳐한거 클라가 넘겨준거 저장해둔거 보내쥼",
        "kakaoUrl" : "http://카카오톡 url",
        "designerInfo": {
		"imgUrl" : "http://디자이너이미지겠죠?",
		"shopName" : "모디 헤어1",								
		"name" : "백모디1",
		"introduction" : "디자이너 자기소개 입니다.",
        }
  }
  ```
- ButtonBox : data.kakaoUrl 전달 
- ImgModal : data.applicationImgUrl 전달
- ProfileWrapperBox : data.designerInfo 전달 

<br />

