### PR TITLE
[LoginPage] 변경된 로그인 로직 반영 및 useType set

### DIFF
--- a/src/views/LoginPage/hooks/type.ts
+++ b/src/views/LoginPage/hooks/type.ts
@@ -14,6 +14,10 @@ export interface loginErrorProps {
     data: {
       code: number;
       message: string;
+      data: {
+        accessToken: string;
+        refreshToken: string;
+      };
     };
   };
 }

--- a/src/views/LoginPage/hooks/usePostLogin.ts
+++ b/src/views/LoginPage/hooks/usePostLogin.ts
@@ -21,7 +21,6 @@ const usePostLogin = () => {
       })
       .then((res: loginResProps) => {
         console.log('로그인 성공');
-        console.log(res.data.data.accessToken);
         // 로그인완료되고 메인뷰로 이동
         setToken(res.data.data.accessToken);
         setUserType(res.data.data.role);

--- a/src/views/LoginPage/hooks/usePostLogin.ts
+++ b/src/views/LoginPage/hooks/usePostLogin.ts
@@ -1,16 +1,13 @@
 import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { useSetRecoilState } from 'recoil';
 
 import { loginErrorProps, loginResProps } from './type';
 
-import { kakaoCodeState } from '@/recoil/atoms/kakaoCodeState';
-import api from '@/views/@common/hooks/api';
+import api, { setToken } from '@/views/@common/hooks/api';
 
 const usePostLogin = () => {
   const KAKAO_CODE = new URL(window.location.href).searchParams.get('code');
   const navigate = useNavigate();
-  const setKakaoCode = useSetRecoilState(kakaoCodeState);
 
   useEffect(() => {
     api
@@ -21,13 +18,15 @@ const usePostLogin = () => {
       })
       .then((res: loginResProps) => {
         console.log('로그인 성공');
-        console.log(res);
+        console.log(res.data.data.accessToken);
         // 로그인완료되고 메인뷰로 이동
+        setToken(res.data.data.accessToken);
+        navigate('/');
       })
       .catch((err: loginErrorProps) => {
         if (err.response.data.code === 404) {
-          setKakaoCode(KAKAO_CODE);
           navigate('/agreement');
+          setToken(err.response.data.data.accessToken);
         } else {
           navigate('/error');
         }

--- a/src/views/LoginPage/hooks/usePostLogin.ts
+++ b/src/views/LoginPage/hooks/usePostLogin.ts
@@ -1,13 +1,16 @@
 import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { useSetRecoilState } from 'recoil';
 
 import { loginErrorProps, loginResProps } from './type';
 
+import { userTypeState } from '@/recoil/atoms/signUpState';
 import api, { setToken } from '@/views/@common/hooks/api';
 
 const usePostLogin = () => {
   const KAKAO_CODE = new URL(window.location.href).searchParams.get('code');
   const navigate = useNavigate();
+  const setUserType = useSetRecoilState(userTypeState);
 
   useEffect(() => {
     api
@@ -21,12 +24,13 @@ const usePostLogin = () => {
         console.log(res.data.data.accessToken);
         // 로그인완료되고 메인뷰로 이동
         setToken(res.data.data.accessToken);
+        setUserType(res.data.data.role);
         navigate('/');
       })
       .catch((err: loginErrorProps) => {
         if (err.response.data.code === 404) {
-          navigate('/agreement');
           setToken(err.response.data.data.accessToken);
+          navigate('/agreement');
         } else {
           navigate('/error');
         }


### PR DESCRIPTION
<!-- PR의 제목은 "[페이지명] 구현내용 " 으로, 연결되는 이슈 제목과 동일하게 가져가시면 됩니다! -->

## ▶️ Related Issue

close #217 

## ✨ DONE Task

- [ ] 변경된 로그인 로직을 반영하기 위해 인가코드를 recoil로 관리하던 atom을 제거함 
- [ ] 로그인 성공 시 사용자의 role을 sessionStorage로 저장하기 위해 userTypeState에 저장함 

<br />

## 💎 PR Point
res.data.data. 이렇게 더럽게 불러오고 있는거
추후 로그인 API 다시 확정될 경우 타입 정의 다시 해서 정리할 예정입니다 ~! 

<br />
