### PR TITLE
[SignUpPage] 전화번호 인증 API 연결

### DIFF
--- a/src/views/SignUpPage/constants/message.ts
+++ b/src/views/SignUpPage/constants/message.ts
@@ -18,6 +18,7 @@ export const HELPER_MESSAGE = {
 
 export const TOAST_MESSAGE = {
   INPUT_EXACT_BIRTH_YEAR: '출생 연도를 정확하게 입력해 주세요',
+  INPUT_EXACT_VERIFY_NUMBER: '인증번호를 정확하게 입력해주세요',
 };
 
 export const PLACE_HOLDER_MESSAGE = {

--- a/src/views/SignUpPage/hooks/type.ts
+++ b/src/views/SignUpPage/hooks/type.ts
@@ -14,3 +14,11 @@ export interface ModelSignUpRequest {
   isMarketingAgree: boolean;
   preferRegions: number[];
 }
+export interface PhoneNumberRequest {
+  phoneNumber: string;
+}
+
+export interface VerifyPhoneNumberRequest {
+  phoneNumber: string;
+  verifyCode: string;
+}

--- a/src/views/SignUpPage/hooks/usePostPhoneNumber.ts
+++ b/src/views/SignUpPage/hooks/usePostPhoneNumber.ts
@@ -1,0 +1,25 @@
+import { useNavigate } from 'react-router-dom';
+
+import { PhoneNumberRequest } from './type';
+
+import api from '@/views/@common/hooks/api';
+
+const usePostPhoneNumber = (phoneNumber: string) => {
+  const navigate = useNavigate();
+
+  const postPhoneNumber = async () => {
+    const requestBody: PhoneNumberRequest = {
+      phoneNumber: phoneNumber,
+    };
+    try {
+      const data = await api.post('/auth/phoneNumber', requestBody);
+      console.log(data);
+    } catch (err) {
+      navigate('/error');
+    }
+  };
+
+  return { postPhoneNumber };
+};
+
+export default usePostPhoneNumber;

--- a/src/views/SignUpPage/hooks/usePostVerifyPhoneNumber.ts
+++ b/src/views/SignUpPage/hooks/usePostVerifyPhoneNumber.ts
@@ -1,0 +1,23 @@
+import { VerifyPhoneNumberRequest } from './type';
+
+import api from '@/views/@common/hooks/api';
+
+const usePostVerifyPhoneNumber = (phoneNumber: string, verifyCode: string) => {
+  const postVerifyPhoneNumber = async () => {
+    const requestBody: VerifyPhoneNumberRequest = {
+      phoneNumber: phoneNumber,
+      verifyCode: verifyCode,
+    };
+    try {
+      const data = await api.post('/auth/phoneNumber/verify', requestBody);
+      console.log(data);
+      return true;
+    } catch (err) {
+      return false;
+    }
+  };
+
+  return { postVerifyPhoneNumber };
+};
+
+export default usePostVerifyPhoneNumber;


### PR DESCRIPTION
<!-- PR의 제목은 "[페이지명] 구현내용 " 으로, 연결되는 이슈 제목과 동일하게 가져가시면 됩니다! -->

## ▶️ Related Issue

close #213

## ✨ DONE Task

- [x] 인증번호 sms로 요청하기 API 연결
- [x] 인증번호 검증하기 API 연결
- [x] 휴대폰 번호가 검증 됐을 때만 요청 가능하도록 수정
- [x] 코드까지 인증 성공했다면 input & button disabled로 수정 불가하게

<br />

## 💎 PR Point

전화번호 11자 안됐을 때도 버튼이 눌리길래 휴대폰 번호가 검증 됐을 때만 요청 가능하도록 수정했습니다
성공했을 떄 다시 요청할 수 없도록 인증 성공 시 input, button 을 disabled 처리 했습니다


<br />

## 🧨 Trouble Shooting
`postVerifyPhoneNumber`를 수행하고나서 그 여부에 따라 `status`를 바꿔줘야 했습니다
`postVerifyPhoneNumber` 함수가 `비동기`이므로, 그 함수의 실행 결과를 기반으로 상태를 업데이트하려면
1) **해당 함수 내에서 상태 업데이트** 로직을 처리하거나,
2) 함수가 프로미스를 반환하도록 하고 **await를 사용하여 결과를 기다린 후 상태를 업데이트**해야 했습니다

커스텀 훅 파일에서 전역상태를 또 한번 불러오는 것은 낭비이기 떄문에 `2번` 해결방법을 사용하였습니다

```javascript
const handleConfirmVerify = async () => {
    if (seconds > 0) {
      if (verifyCode.status === STATUS.AVAILABLE) {
        const success = await postVerifyPhoneNumber();
        if (success) { // 성공시 상태값 업데이트
          setPhoneNumber({
            data: phoneNumber.data,
            status: STATUS.DONE,
          });
          setVerifyCode({
            data: verifyCode.data,
            status: STATUS.VERIFIED,
          });
        } else {
          setToastOpen(true); // 잘못된 인증번호를 입력했다는 토스트 메세지 ~~
        }
      }
    }
  };
```

<br />

## 🖼️ Screenshot

https://github.com/TEAM-MODDY/moddy-web/assets/46593078/0ae8621e-9602-4769-a5e2-7c4675d44e31

