### PR TITLE
[bugfix] response 값에 따라 userType 분기 저장

### DIFF
--- a/src/views/LoginPage/hooks/usePostLogin.ts
+++ b/src/views/LoginPage/hooks/usePostLogin.ts
@@ -20,8 +20,9 @@ const usePostLogin = () => {
         },
       })
       .then((res: loginResProps) => {
-        setToken(res.data.data.accessToken);
-        setUserType(res.data.data.role);
+        const { role, accessToken } = res.data.data;
+        setToken(accessToken);
+        setUserType(role === 'MODEL' ? 'model' : 'designer');
         navigate('/');
       })
       .catch((err: loginErrorProps) => {


### PR DESCRIPTION
<!-- PR의 제목은 "[페이지명] 구현내용 " 으로, 연결되는 이슈 제목과 동일하게 가져가시면 됩니다! -->

## ▶️ Related Issue

- close #256 

## ✨ DONE Task

- [x] 분기저장 ! 

<br />

## 💎 PR Point
localStorage에서 불러오는 userType이 로그인시 들어오는 response를 그대로 박아줬는데, 
수빈이 쪽에서 endpoint에 바로 사용하기 때문에 분기처리해서 다른 값으로 넣어주었습니다 ! 
```ts
.then((res: loginResProps) => {
        const { role, accessToken } = res.data.data;
        setToken(accessToken);
        setUserType(role === 'MODEL' ? 'model' : 'designer');
        navigate('/');
      })
```


