### PR TITLE
[bugfix] 회원탈퇴, 로그아웃 시 recoil state 초기화 

### DIFF
--- a/src/views/@common/utils/removeToken.ts
+++ b/src/views/@common/utils/removeToken.ts
@@ -1,6 +1,6 @@
 const removeToken = () => {
   localStorage.removeItem('token');
-  localStorage.removeItem('recoil-persist');
+  localStorage.removeItem('사용자 타입');
 };
 
 export default removeToken;

--- a/src/views/LoginPage/hooks/usePostLogin.ts
+++ b/src/views/LoginPage/hooks/usePostLogin.ts
@@ -20,8 +20,9 @@ const usePostLogin = () => {
         },
       })
       .then((res: loginResProps) => {
-        setToken(res.data.data.accessToken);
-        setUserType(res.data.data.role);
+        const { role, accessToken } = res.data.data;
+        setToken(accessToken);
+        setUserType(role === 'MODEL' ? 'model' : 'designer');
         navigate('/');
       })
       .catch((err: loginErrorProps) => {

--- a/src/views/MyPage/hooks/useDeleteUser.ts
+++ b/src/views/MyPage/hooks/useDeleteUser.ts
@@ -1,20 +1,19 @@
 import { useNavigate } from 'react-router-dom';
-import { useSetRecoilState } from 'recoil';
+import { useResetRecoilState } from 'recoil';
 
 import { userTypeState } from '@/recoil/atoms/signUpState';
-import { USER_TYPE } from '@/views/@common/constants/userType';
 import api from '@/views/@common/hooks/api';
 import removeToken from '@/views/@common/utils/removeToken';
 
 const useDeleteUser = () => {
   const navigate = useNavigate();
-  const setUserType = useSetRecoilState(userTypeState);
+  const resetType = useResetRecoilState(userTypeState);
 
   const deleteUser = async () => {
     try {
       await api.delete('/user');
       removeToken();
-      setUserType(USER_TYPE.GUEST);
+      resetType();
       navigate('/');
     } catch (err) {
       navigate('/error');

--- a/src/views/MyPage/hooks/useDeleteUser.ts
+++ b/src/views/MyPage/hooks/useDeleteUser.ts
@@ -1,15 +1,20 @@
 import { useNavigate } from 'react-router-dom';
+import { useSetRecoilState } from 'recoil';
 
+import { userTypeState } from '@/recoil/atoms/signUpState';
+import { USER_TYPE } from '@/views/@common/constants/userType';
 import api from '@/views/@common/hooks/api';
 import removeToken from '@/views/@common/utils/removeToken';
 
 const useDeleteUser = () => {
   const navigate = useNavigate();
+  const setUserType = useSetRecoilState(userTypeState);
 
   const deleteUser = async () => {
     try {
       await api.delete('/user');
       removeToken();
+      setUserType(USER_TYPE.GUEST);
       navigate('/');
     } catch (err) {
       navigate('/error');

--- a/src/views/MyPage/hooks/usePostLogout.ts
+++ b/src/views/MyPage/hooks/usePostLogout.ts
@@ -1,15 +1,20 @@
 import { useNavigate } from 'react-router-dom';
+import { useSetRecoilState } from 'recoil';
 
+import { userTypeState } from '@/recoil/atoms/signUpState';
+import { USER_TYPE } from '@/views/@common/constants/userType';
 import api from '@/views/@common/hooks/api';
 import removeToken from '@/views/@common/utils/removeToken';
 
 const usePostLogout = () => {
   const navigate = useNavigate();
+  const setUserType = useSetRecoilState(userTypeState);
 
   const postLogout = async () => {
     try {
       await api.post('/auth/logout', null);
       removeToken();
+      setUserType(USER_TYPE.GUEST);
       navigate('/');
     } catch (err) {
       console.log(err);

--- a/src/views/MyPage/hooks/usePostLogout.ts
+++ b/src/views/MyPage/hooks/usePostLogout.ts
@@ -1,20 +1,18 @@
 import { useNavigate } from 'react-router-dom';
-import { useSetRecoilState } from 'recoil';
+import { useResetRecoilState } from 'recoil';
 
 import { userTypeState } from '@/recoil/atoms/signUpState';
-import { USER_TYPE } from '@/views/@common/constants/userType';
 import api from '@/views/@common/hooks/api';
 import removeToken from '@/views/@common/utils/removeToken';
 
 const usePostLogout = () => {
   const navigate = useNavigate();
-  const setUserType = useSetRecoilState(userTypeState);
-
+  const resetType = useResetRecoilState(userTypeState);
   const postLogout = async () => {
     try {
       await api.post('/auth/logout', null);
       removeToken();
-      setUserType(USER_TYPE.GUEST);
+      resetType();
       navigate('/');
     } catch (err) {
       console.log(err);


### PR DESCRIPTION
<!-- PR의 제목은 "[페이지명] 구현내용 " 으로, 연결되는 이슈 제목과 동일하게 가져가시면 됩니다! -->

## ▶️ Related Issue

- close #256 

## ✨ DONE Task

- [x] ~~setUserType(USER_TYPE.GUEST); 추가~~
- [x] useResetRecoilState 활용하여 userType 초기화

<br />

## 💎 PR Point
localStorage에 있는 type을 삭제해주어도 401 에러가 나는 문제가 있었습니다. 
localStorage가 recoilState에 동적으로 바로바로 반영되지 않는 문제인 것으로 추측되어 
별도로 recoilState를 USER_TYPE.GUEST로 초기화해주어서 해결했습니다 
**-> useResetRecoilState 활용하여 userType 초기화 방식으로 변경** 

```ts
const resetType = useResetRecoilState(userTypeState);

await api.post('/auth/logout', null);
      removeToken();
      resetType();
      navigate('/');
```
<br />

