### PR TITLE
[QA] 메인뷰 지원서/제안서 사진 위치 조정

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,28 +1,34 @@
 <!doctype html>
 <html lang="ko">
-  <head>
-    <meta charset="UTF-8" />
-    <meta content="moddy, 지출 없이 예쁜 머리" property="og:title" />
-    <meta content="https://moddy.kr" property="og:url" />
-    <meta content="https://www.moddy.kr/og_image.png" property="og:image" />
-    <meta content="쉬운 헤어모델 연결플랫폼" property="og:description" />
-    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0" />
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      href="https://fonts.googleapis.com/css2?family=MuseoModerno:ital,wght@1,300;1,400&display=swap"
-      rel="stylesheet" />
-    <link
-      rel="stylesheet"
-      as="style"
-      crossorigin
-      href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/variable/pretendardvariable.min.css" />
-    <title>Moddy</title>
-  </head>
 
-  <body>
-    <div id="root"></div>
-    <script type="module" src="/src/main.tsx"></script>
-  </body>
+<head>
+  <meta charset="UTF-8" />
+  <meta content="moddy, 지출 없이 예쁜 머리" property="og:title" />
+  <meta content="https://moddy.kr" property="og:url" />
+  <meta content="https://www.moddy.kr/og_image.png" property="og:image" />
+  <meta content="쉬운 헤어모델 연결플랫폼" property="og:description" />
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0" />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=MuseoModerno:ital,wght@1,300;1,400&display=swap"
+    rel="stylesheet" />
+  <link rel="stylesheet" as="style" crossorigin
+    href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/variable/pretendardvariable.min.css" />
+  <title>Moddy</title>
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-BBHL939ELH"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag() { dataLayer.push(arguments); }
+    gtag('js', new Date());
+
+    gtag('config', 'G-BBHL939ELH');
+  </script>
+</head>
+
+<body>
+  <div id="root"></div>
+  <script type="module" src="/src/main.tsx"></script>
+</body>
+
 </html>

--- a/src/views/MainPage/components/Card.tsx
+++ b/src/views/MainPage/components/Card.tsx
@@ -31,12 +31,10 @@ const OfferCard = (props: OfferCardProps) => {
           <ImgNew />
         </S.NewTagBox>
       )}
-      <S.ProfileImageBox>
-        <img src={imgUrl} alt="프로필 이미지" />
-      </S.ProfileImageBox>
+      <S.ProfileImageBox $img={imgUrl} title="제안서 프로필 사진" />
       <S.ModelInfoBox>
         <S.PersonalInfoBox>
-          <S.NameSpan>{name.slice(0, 5)}</S.NameSpan>
+          <S.NameSpan>{name}</S.NameSpan>
           <S.AgeGenderSpan>{shopName}</S.AgeGenderSpan>
         </S.PersonalInfoBox>
         <S.PreferStyleWrapperBox>
@@ -54,12 +52,10 @@ const ApplicationCard = (props: ApplicationCardProps) => {
   const { applicationId, name, age, imgUrl, gender, preferHairStyles } = props;
   return (
     <S.ApplicationCardLayout onClick={() => navigate('/model-info', { state: applicationId })}>
-      <S.ProfileImageBox>
-        <img src={imgUrl} alt="프로필 이미지" />
-      </S.ProfileImageBox>
+      <S.ProfileImageBox $img={imgUrl} title="지원서 프로필 사진" />
       <S.ModelInfoBox>
         <S.PersonalInfoBox>
-          <S.NameSpan>{name.slice(0, 5)}</S.NameSpan>
+          <S.NameSpan>{name}</S.NameSpan>
           <S.AgeGenderSpan>
             {age}세 / {gender}
           </S.AgeGenderSpan>
@@ -87,13 +83,13 @@ const ApplicationCardLayout = styled.button`
   box-shadow: ${({ theme }) => theme.effects.shadow1};
 `;
 
-const ProfileImageBox = styled.div`
+const ProfileImageBox = styled.div<{ $img: string }>`
   overflow: hidden;
 
   min-width: 16.4rem;
   height: 16.4rem;
   border-radius: 12px 12px 0 0;
-
+  background: center/cover ${({ $img }) => `url(${$img})`} no-repeat;
   & > img {
     width: 100%;
   }


### PR DESCRIPTION
<!-- PR의 제목은 "[QA] 내용 " 으로, 연결되는 이슈 제목과 동일하게 가져가시면 됩니다! -->
![QA](https://github.com/TEAM-MODDY/moddy-web/assets/81505421/3749ec71-89ed-4ccf-9b22-e7912bed83de)

## ▶️ Related Issue

- close #300

## 🚨 Problem

<!-- 발견된 QA 사항 작성 -->
메인뷰 지원/제안서 카드 이미지가 중앙에 안오고 위에부터 나옴
![image](https://github.com/TEAM-MODDY/moddy-web/assets/46593078/734d04fd-6d02-492c-b634-b1966335e718)


<br />

## 🚑 Solution

<!-- 어떻게 해결했는지 -->
background img 로 넣어서 center/cover 로 중앙에 맞춰줬습니다
```css
background: center/cover ${({ $img }) => `url(${$img})`} no-repeat;
```
<br />

## 📸 Screenshot
<img width="328" alt="스크린샷 2024-01-18 오후 4 52 57" src="https://github.com/TEAM-MODDY/moddy-web/assets/46593078/4e60a8ab-d598-4eb4-b9e7-5472e3b1564f">

