### PR TITLE
[QA] token과 userType local->SessionStorage

### DIFF
--- a/src/recoil/atoms/signUpState.ts
+++ b/src/recoil/atoms/signUpState.ts
@@ -33,7 +33,7 @@ export interface inputImgType {
 
 const { persistAtom } = recoilPersist({
   key: '사용자 타입',
-  storage: localStorage,
+  storage: sessionStorage,
 });
 
 export const userTypeState = atom({

--- a/src/views/@common/hooks/api.ts
+++ b/src/views/@common/hooks/api.ts
@@ -7,11 +7,11 @@ const api: AxiosInstance = axios.create({
 const ACCESS_TOKEN = 'token';
 
 export const getToken = () => {
-  return localStorage.getItem(ACCESS_TOKEN);
+  return sessionStorage.getItem(ACCESS_TOKEN);
 };
 
 export const setToken = (token: string) => {
-  localStorage.setItem(ACCESS_TOKEN, token);
+  sessionStorage.setItem(ACCESS_TOKEN, token);
 };
 
 api.interceptors.request.use((config) => {

--- a/src/views/@common/utils/removeToken.ts
+++ b/src/views/@common/utils/removeToken.ts
@@ -1,6 +1,5 @@
 const removeToken = () => {
-  localStorage.removeItem('token');
-  localStorage.removeItem('사용자 타입');
+  sessionStorage.clear();
 };
 
 export default removeToken;


### PR DESCRIPTION
<!-- PR의 제목은 "[QA] 내용 " 으로, 연결되는 이슈 제목과 동일하게 가져가시면 됩니다! -->
![QA](https://github.com/TEAM-MODDY/moddy-web/assets/81505421/3749ec71-89ed-4ccf-9b22-e7912bed83de)

## ▶️ Related Issue

- close #299 

## 🚨 Problem

<!-- 발견된 QA 사항 작성 -->
A기기를 쓰던 유저가 B기기로 옮겨서 서비스를 이용하다가 탈퇴를 하면, 
A기기는 계속 토큰이 저장되어있기 때문에 에러가 발생하게 될 수 있다. 
이러한 경우를 대비하고자 로그인토큰을 localStorage가 아니라 sessionStorage로 저장하고자 한다. 
<br />


## 🚑 Solution

<!-- 어떻게 해결했는지 -->
userTypeState와 카카오 토큰을 sessionStorage로 관리한다. 
⭐️ 브라우저를 킬때마다 로그인이 풀려있으면 사용성이 떨어지지 않을까 고민했으나, 카카오 자체 캐시 덕분에 카카오로그인의 과정이 생략되어 사용성에 문제가 없다는 결론을 내렸다! 

<br />

## 📸 Screenshot
### 기존에는 이렇게 브라우저를 다시 켜도 로그인이 유지된다. 

https://github.com/TEAM-MODDY/moddy-web/assets/81505421/5c284760-7f8b-4169-914f-fa12e6d1234a



### 세션스토리지를 관리하면 이렇게 브라우저를 킬때마다 로그인이 풀려있다 



https://github.com/TEAM-MODDY/moddy-web/assets/81505421/457670a7-e4d8-4e34-913a-ac2e5e0a9b0e


<!-- 없으면 삭제 -->
