### PR TITLE
[QA] 메인페이지 통신 오류시 에러 헨들링 로직 수정

### DIFF
--- a/src/views/MainPage/hooks/useGetMain.tsx
+++ b/src/views/MainPage/hooks/useGetMain.tsx
@@ -1,11 +1,11 @@
 import { AxiosError } from 'axios';
 import { useEffect, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
 
 import { DesignerResponse, ModelResponse } from './type';
 
 import { USER_TYPE } from '@/views/@common/constants/userType';
 import api from '@/views/@common/hooks/api';
+import removeToken from '@/views/@common/utils/removeToken';
 
 interface UseGetModelProps {
   user: string;
@@ -13,7 +13,6 @@ interface UseGetModelProps {
 }
 
 const useGetMain = ({ user, page }: UseGetModelProps) => {
-  const navigate = useNavigate();
   const [data, setData] = useState<ModelResponse | DesignerResponse>();
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<AxiosError>();
@@ -41,7 +40,8 @@ const useGetMain = ({ user, page }: UseGetModelProps) => {
       });
     } catch (err) {
       if (err instanceof AxiosError) setError(err);
-      navigate('/error');
+      removeToken();
+      location.reload();
     } finally {
       setLoading(false);
     }


### PR DESCRIPTION
<!-- PR의 제목은 "[QA] 내용 " 으로, 연결되는 이슈 제목과 동일하게 가져가시면 됩니다! -->
![QA](https://github.com/TEAM-MODDY/moddy-web/assets/81505421/3749ec71-89ed-4ccf-9b22-e7912bed83de)

## ▶️ Related Issue

- close #303 

## 🚨 Problem

<!-- 발견된 QA 사항 작성 -->
메인페이지에서 오류가 났을 경우 에러페이지로 이동해서 아무것도 할 수 없는 굴레에 빠짐..

<br />

## 🚑 Solution

<!-- 어떻게 해결했는지 -->
사용자가 휴대폰으로 토큰을 지워줄 수 없기 때문에 에러핸들링에 토큰 삭제 후 강제 새로고침 처리
```javascript
catch (err) {
  removeToken();
  location.reload();
}
```
