### PR TITLE
[QA] 희망스타일 state 미반영 사항 수정

### DIFF
--- a/src/views/ApplicationPage/components/DefaultInfo.tsx
+++ b/src/views/ApplicationPage/components/DefaultInfo.tsx
@@ -28,7 +28,7 @@ const DefaultInfo = () => {
   }, [length, preference]);
 
   const activateCheckbox = (type: string): boolean => {
-    return preference.some((element) => element === type);
+    return preference.includes(type);
   };
 
   return (

--- a/src/views/ApplicationPage/components/DefaultInfo.tsx
+++ b/src/views/ApplicationPage/components/DefaultInfo.tsx
@@ -27,6 +27,10 @@ const DefaultInfo = () => {
       : setSelectedStyle({ ...selectedStyle, verifyStatus: false });
   }, [length, preference]);
 
+  const activateCheckbox = (type: string): boolean => {
+    return preference.some((element) => element === type);
+  };
+
   return (
     <S.DefaultInfoLayout>
       <Header
@@ -65,23 +69,23 @@ const DefaultInfo = () => {
             </S.Title>
             <S.StyleBox>
               <h3>{SELECT_TYPE.CUT}</h3>
-              <StyleButton isSelected={false} type="일반 커트" />
+              <StyleButton isSelected={activateCheckbox('일반 커트')} type="일반 커트" />
             </S.StyleBox>
             <hr />
             <S.StyleBox>
               <h3>{SELECT_TYPE.COLOR}</h3>
               <S.SelectList>
-                <StyleButton isSelected={false} type="전체 염색" />
-                <StyleButton isSelected={false} type="전체 탈색" />
+                <StyleButton isSelected={activateCheckbox('전체 염색')} type="전체 염색" />
+                <StyleButton isSelected={activateCheckbox('전체 탈색')} type="전체 탈색" />
               </S.SelectList>
             </S.StyleBox>
             <hr />
             <S.StyleBox>
               <h3>{SELECT_TYPE.PERM}</h3>
               <S.SelectList>
-                <StyleButton isSelected={false} type="셋팅펌" />
-                <StyleButton isSelected={false} type="일반펌" />
-                <StyleButton isSelected={false} type="매직" />
+                <StyleButton isSelected={activateCheckbox('셋팅펌')} type="셋팅펌" />
+                <StyleButton isSelected={activateCheckbox('일반펌')} type="일반펌" />
+                <StyleButton isSelected={activateCheckbox('매직')} type="매직" />
               </S.SelectList>
             </S.StyleBox>
           </S.DeserveStyleSection>
@@ -91,7 +95,6 @@ const DefaultInfo = () => {
         text={INFO_MESSAGE.NEXT}
         onClickFn={() => {
           setStep({ ...step, current: step.current + 1 });
-          console.log(selectedStyle);
         }}
         isFixed={true}
         disabled={!verifyStatus}

--- a/src/views/ApplicationPage/components/StyleButton.tsx
+++ b/src/views/ApplicationPage/components/StyleButton.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import { useRecoilState } from 'recoil';
 import { styled } from 'styled-components';
 
@@ -15,12 +15,6 @@ const StyleButton = ({ type, isSelected }: StyleButtonProps) => {
   const [selectedStyle, setSelectedStyle] = useRecoilState(hairStyleState);
   const { preference } = selectedStyle;
   const [activate, setActivate] = useState(isSelected);
-
-  useEffect(() => {
-    preference.forEach((element) => {
-      element === type ? setActivate(true) : setActivate(false);
-    });
-  }, []);
 
   const styleResult = () => {
     if (activate) {


### PR DESCRIPTION
<!-- PR의 제목은 "[QA] 내용 " 으로, 연결되는 이슈 제목과 동일하게 가져가시면 됩니다! -->
![QA](https://github.com/TEAM-MODDY/moddy-web/assets/81505421/3749ec71-89ed-4ccf-9b22-e7912bed83de)

## ▶️ Related Issue

- close #307 

## 🚨 Problem

<!-- 발견된 QA 사항 작성 -->
체크 박스를 선택하고 다음단계 갔다가 돌아오면 체크 여부가 반영되지 않는 문제가 발생

<br />

## 🚑 Solution

<!-- 어떻게 해결했는지 -->
처음엔 각 styleButton 컴포넌트에서 useEffect를 통해 체크 활성화/비활성 여부를 렌더링 해주도록 설정

공식 문서에 의하면
> 기본적으로 동작은 모든 렌더링이 완료된 후에 수행됩니다만, 어떤 값이 변경되었을 때만 실행되게 할 수도 있습니다.
다음과 같이 나와있다.
따라서, 이미 렌더링이 완료된 상태에서 함수가 실행되기 때문에 이미 지정해준 활성화 여부의 초기값(false)에서 변경이 되지 않는 것이었다 ! ! !

<결론>
상위 컴포넌트로 체크박스 활성화 여부를 state로 빼주었다.
```tsx
  const activateCheckbox = (type: string): boolean => {
    return preference.some((element) => element === type);
  };
```
`Array.prototype.some()` 메서드 이용
> ❓`some()` 메서드는 배열 안의 어떤 요소라도 주어진 판별 함수를 적어도 하나라도 통과하는지 테스트한다면 true를 반환하고 그렇지 않으면 false를 반환합니다. (배열을 변경하지는 않는다)

<br />

## 📸 Screenshot

<!-- 없으면 삭제 -->
- 기본 스타일 선택으로 되돌아가기
![Moddy - Chrome 2024-01-18 21-09-40](https://github.com/TEAM-MODDY/moddy-web/assets/101045330/2bcf328d-3ad4-4072-9bff-bce370449d95)

- 최종 결과 화면
![Moddy - Chrome 2024-01-18 21-10-19](https://github.com/TEAM-MODDY/moddy-web/assets/101045330/c222940f-b186-4d63-9f5c-a1f509c24b50)
