### PR TITLE
fix: z-index 수정

### DIFF
--- a/src/views/OfferInfoPage/components/DirectionModal.tsx
+++ b/src/views/OfferInfoPage/components/DirectionModal.tsx
@@ -83,7 +83,7 @@ const S = {
     align-items: center;
     position: fixed;
     top: 0;
-    z-index: 2;
+    z-index: 5;
 
     width: 100%;
     max-width: 43rem;

--- a/src/views/OfferInfoPage/components/ImgModal.tsx
+++ b/src/views/OfferInfoPage/components/ImgModal.tsx
@@ -62,7 +62,7 @@ const S = {
     align-items: center;
     position: fixed;
     top: 0;
-    z-index: 4;
+    z-index: 5;
 
     width: 100%;
     max-width: 43rem;


### PR DESCRIPTION
<!-- PR의 제목은 "[QA] 내용 " 으로, 연결되는 이슈 제목과 동일하게 가져가시면 됩니다! -->
![QA](https://github.com/TEAM-MODDY/moddy-web/assets/81505421/3749ec71-89ed-4ccf-9b22-e7912bed83de)

## ▶️ Related Issue

- close #323

## 🚨 Problem

<!-- 발견된 QA 사항 작성 -->
header의 z-index 수정하면서 img modal 위로 올라가게 되었어요
<br />

## 🚑 Solution

<!-- 어떻게 해결했는지 -->
z-index: 5먹였습니다~~~

<br />

## 📸 Screenshot

<!-- 없으면 삭제 -->
