### PR TITLE
[QA] 메인 뷰 아래 박스 라이팅 수정

### DIFF
--- a/src/views/MainPage/components/UserContents.tsx
+++ b/src/views/MainPage/components/UserContents.tsx
@@ -40,9 +40,13 @@ const ReceivedOffer = (props: UserContentsProps) => {
       ) : (
         <S.EmptyBox>
           <S.HelperTextSpan>
-            {'status' in data && data.status === APPLY_STATUS.NOTHING
-              ? '지금 바로 헤어모델에 지원해 보세요 :)'
-              : '첫 제안서를 기다리고 있어요 :)'}
+            {'status' in data && data.status === APPLY_STATUS.NOTHING ? (
+              '지금 바로 헤어모델에 지원해 보세요 :)'
+            ) : (
+              <S.LineHeightSpan>
+                조금만 기다리면 <br /> 디자이너의 모델 제안을 문자로 보내드릴게요 :&#41;
+              </S.LineHeightSpan>
+            )}
           </S.HelperTextSpan>
         </S.EmptyBox>
       )}
@@ -107,7 +111,12 @@ const EmptyBox = styled.div`
 
 const HelperTextSpan = styled.span`
   color: ${({ theme }) => theme.colors.moddy_gray50};
+  text-align: center;
   ${({ theme }) => theme.fonts.Headline04};
+`;
+
+const LineHeightSpan = styled(HelperTextSpan)`
+  line-height: 1.4;
 `;
 
 const ContentsBox = styled.div`
@@ -124,4 +133,5 @@ const S = {
   TitleSpan,
   HelperTextSpan,
   ContentsBox,
+  LineHeightSpan,
 };


### PR DESCRIPTION
<!-- PR의 제목은 "[QA] 내용 " 으로, 연결되는 이슈 제목과 동일하게 가져가시면 됩니다! -->
![QA](https://github.com/TEAM-MODDY/moddy-web/assets/81505421/3749ec71-89ed-4ccf-9b22-e7912bed83de)

## ▶️ Related Issue

- close #321

## 💎 PR Point

기획이 워딩 수정 요청하여 변경하였습니다

<br />

## 🧨 Trouble Shooting

```tsx
<S.HelperTextSpan>
  {'status' in data && data.status === APPLY_STATUS.NOTHING ? (
    '지금 바로 헤어모델에 지원해 보세요 :)'
  ) : '조금만 기다리면 <br /> 디자이너의 모델 제안을 문자로 보내드릴게요'}
</S.HelperTextSpan>
```

이렇게 했는데 br태그가 그대로 출력됐습니다..

> React에서 JSX는 HTML과 유사하지만, 문자열 내에서 HTML 태그를 직접 사용하는 것은 기본적으로 지원되지 않습니다. 이는 보안상의 이유로, React는 문자열 내의 HTML을 그대로 렌더링하지 않고 이스케이프 처리합니다. 따라서 `<br />` 태그가 문자열로 인식되어 개행이 적용되지 않는 것입니다.

해결 방법 

1. **`dangerouslySetInnerHTML` 사용**

```jsx
<S.HelperTextSpan dangerouslySetInnerHTML={{ __html: 'status' in data && data.status === APPLY_STATUS.NOTHING
  ? '지금 바로 헤어모델에 지원해 보세요 :)'
  : `조금만 기다리면 <br />디자이너의 모델 제안을 문자로 보내드릴게요` }}>
</S.HelperTextSpan>
```

1. **`JSX 요소` 사용**

```jsx
<S.HelperTextSpan>
  {'status' in data && data.status === APPLY_STATUS.NOTHING
    ? '지금 바로 헤어모델에 지원해 보세요 :)'
    : <>조금만 기다리면 <br />디자이너의 모델 제안을 문자로 보내드릴게요</>}
</S.HelperTextSpan>
```

1의 방법을 사용하면 XSS 공격( https://nordvpn.com/ko/blog/xss-attack/ )에 취약할 수 있다고 한다

그래서 2의 방법을 사용하였다

그런데 2번의 방식을 사용했더니 line-height가 안먹히는 문제가 있었다

```tsx
<S.HelperTextSpan>
  {'status' in data && data.status === APPLY_STATUS.NOTHING ? (
    '지금 바로 헤어모델에 지원해 보세요 :)'
  ) : (
    <S.LineHeightSpan>
      조금만 기다리면 <br /> 디자이너의 모델 제안을 문자로 보내드릴게요
    </S.LineHeightSpan>
  )}
</S.HelperTextSpan>
```

```css
const HelperTextSpan = styled.span`
  color: ${({ theme }) => theme.colors.moddy_gray50};
  text-align: center;
  ${({ theme }) => theme.fonts.Headline04};
`;

const LineHeightSpan = styled(HelperTextSpan)`
  line-height: 1.4;
`;
```

그래서 이렇게 span 하나 더 만들어서 감싸줬습니다

<br />

## 📸 Screenshot

<!-- 없으면 삭제 -->
![스크린샷 2024-01-18 오후 11 40 54](https://github.com/TEAM-MODDY/moddy-web/assets/46593078/129ee7f4-0cd4-4399-bff3-c173d9434750)
