### PR TITLE
[QA] 공통컴포넌트 Header에서 모달 없는 버전 추가 

### DIFF
--- a/src/views/@common/components/Header.tsx
+++ b/src/views/@common/components/Header.tsx
@@ -12,13 +12,14 @@ interface HeaderProps {
   title: string;
   backFn?: () => void;
   closeFn?: () => void;
+  isNoModal?: boolean;
 }
 
-const Header = ({ isBackBtnExist, isCloseBtnExist, title, backFn, closeFn }: HeaderProps) => {
+const Header = ({ isBackBtnExist, isCloseBtnExist, title, backFn, closeFn, isNoModal }: HeaderProps) => {
   const navigate = useNavigate();
   const [isOpenModal, setOpenModal] = useState(false);
   const onClose = () => {
-    setOpenModal(true);
+    isNoModal ? navigate('/') : setOpenModal(true);
   };
   return (
     <S.HeaderLayout>

--- a/src/views/OfferInfoPage/components/CheckOfferPage.tsx
+++ b/src/views/OfferInfoPage/components/CheckOfferPage.tsx
@@ -46,6 +46,7 @@ const CheckOfferPage = () => {
           isCloseBtnExist={true}
           backFn={handleClickBack}
           closeFn={handleClickClose}
+          isNoModal
         />
         <S.CheckOfferLayout>
           <ImgBox />


### PR DESCRIPTION
<!-- PR의 제목은 "[QA] 내용 " 으로, 연결되는 이슈 제목과 동일하게 가져가시면 됩니다! -->
![QA](https://github.com/TEAM-MODDY/moddy-web/assets/81505421/3749ec71-89ed-4ccf-9b22-e7912bed83de)

## ▶️ Related Issue

- close #328 

## 🚨 Problem
<img width="347" alt="스크린샷 2024-01-19 오전 12 03 49" src="https://github.com/TEAM-MODDY/moddy-web/assets/81505421/a12e851e-2316-45f5-a4fe-8b0c02857326">
완료 페이지에서 헤더 클로즈 버튼을 클릭하면 이탈 모달이 뜹니다. 
공통 헤더 컴포넌트에 모달이 디폴트로 포함되어있어서 그런데요, 
완료 페이지의 경우 이탈이 아니라 X버튼 클릭 시 바로 홈으로 가야합니다. 
<!-- 발견된 QA 사항 작성 -->


<br />

## 🚑 Solution
### Header
```tsx
interface HeaderProps {
  isBackBtnExist?: boolean;
  isCloseBtnExist?: boolean;
  title: string;
  backFn?: () => void;
  closeFn?: () => void;
  isNoModal?: boolean;
}
...
  const onClose = () => {
    isNoModal ? navigate('/') : setOpenModal(true);
  };
```

###CheckOfferPage
```tsx
<Header
  title=""
  isBackBtnExist={true}
  isCloseBtnExist={true}
  backFn={handleClickBack}
  closeFn={handleClickClose}
  isNoModal
/>
```


<!-- 어떻게 해결했는지 -->

<br />

## 📸 Screenshot

https://github.com/TEAM-MODDY/moddy-web/assets/81505421/d41d9cf4-fc23-49f2-adf3-1a0ba946360c

<!-- 없으면 삭제 -->
