### PR TITLE
[QA] 렌더링이 느린 요소에 height 지정

### DIFF
--- a/src/pages/AgreementPage.tsx
+++ b/src/pages/AgreementPage.tsx
@@ -21,7 +21,7 @@ const AgreementPage = () => {
 
   const handleChurn = () => {
     removeToken();
-    navigate('/');
+    navigate('/login');
   };
 
   return (

--- a/src/views/MainPage/components/TopSheet.tsx
+++ b/src/views/MainPage/components/TopSheet.tsx
@@ -113,6 +113,8 @@ const LoginSpan = styled.span`
 `;
 
 const OnBoardingParagraph = styled.p`
+  height: 5.6rem;
+
   color: ${({ theme }) => theme.colors.moddy_wt};
   ${({ theme }) => theme.fonts.Title02};
 `;

--- a/src/views/SignUpPage/components/UserType.tsx
+++ b/src/views/SignUpPage/components/UserType.tsx
@@ -120,6 +120,7 @@ const UserTypeBoxLabel = styled.label`
   flex-grow: 1;
 
   width: 16.4rem;
+  height: 18.7rem;
   padding: 1.4rem 0;
   border: 1.5px solid ${({ theme }) => theme.colors.moddy_gray20};
   border-radius: 12px;
@@ -129,6 +130,7 @@ const UserTypeBoxLabel = styled.label`
 
 const ImageBox = styled.div`
   width: 10rem;
+  height: 9.7rem;
 
   background-color: transparent;
   filter: drop-shadow(0 0 3rem rgb(82 0 255 / 25%));


### PR DESCRIPTION
<!-- PR의 제목은 "[QA] 내용 " 으로, 연결되는 이슈 제목과 동일하게 가져가시면 됩니다! -->
![QA](https://github.com/TEAM-MODDY/moddy-web/assets/81505421/3749ec71-89ed-4ccf-9b22-e7912bed83de)

## ▶️ Related Issue

- close #335

## 🚨 Problem

렌더링 시 짧았다가 길어져버려~
사용자경험이 좋지 못해요

<br />

## 🚑 Solution

<!-- 어떻게 해결했는지 -->
height 기본 값 설정

<br />

## 💎 PR Point

이거 하다가 아까 이용약관 페이지에서 뒤로 갔을 때 홈화면으로 처리해서 login페이지로 가도록 수정해줬어요 (이슈안파서 미안합니다)
