### PR TITLE
[QA] 이미지 저장하기 버튼 스타일 변경

### DIFF
--- a/src/views/OfferInfoPage/components/ImgModal.tsx
+++ b/src/views/OfferInfoPage/components/ImgModal.tsx
@@ -13,6 +13,7 @@ interface ImgModalProps {
 }
 
 const ImgModal = ({ isModal, onClose, imgUrl }: ImgModalProps) => {
+  console.log(imgUrl);
   const data = usePostDownloadUrlOffer(imgUrl);
 
   const handleImgDownload = () => {
@@ -95,6 +96,8 @@ const S = {
   `,
 
   SaveBtn: styled.a`
+    display: block;
+
     width: 100%;
     margin: 4rem 0 3.2rem;
     padding: 1.25rem 0;
@@ -103,7 +106,8 @@ const S = {
     background-color: ${({ theme }) => theme.colors.moddy_blue};
 
     color: ${({ theme }) => theme.colors.moddy_wt};
-    ${({ theme }) => theme.fonts.Headline01};
+    text-align: center;
+    ${({ theme }) => theme.fonts.Headline02};
   `,
 
   BookMarkBox: styled.div`


### PR DESCRIPTION
<!-- PR의 제목은 "[QA] 내용 " 으로, 연결되는 이슈 제목과 동일하게 가져가시면 됩니다! -->
![QA](https://github.com/TEAM-MODDY/moddy-web/assets/81505421/3749ec71-89ed-4ccf-9b22-e7912bed83de)

## ▶️ Related Issue

- close #325 

## 🚨 Problem

<!-- 발견된 QA 사항 작성 -->
이미지가 안들어오고, 버튼의 레이아웃이 안맞는 이슈입니다. 
![image](https://github.com/TEAM-MODDY/moddy-web/assets/81505421/e5df1fc4-4abd-436d-837b-96bfd87452e3)

<br />

## 🚑 Solution
이미지 저장하기 버튼을 기존엔 button 태그를 사용하다가, 
이미지 다운로드 방식이 다운로드 url을 접속하는 방식으로 바뀌면서 a태그로 변경해주었습니다. 
button 태그는 display: block이고, a태그는 display: inline이라서 해당 문제가 발생한 것이어서 
display를 block으로 지정해주어 해결했습니다 . 

<!-- 어떻게 해결했는지 -->

<br />

## 📸 Screenshot
<img width="458" alt="스크린샷 2024-01-19 오후 5 01 13" src="https://github.com/TEAM-MODDY/moddy-web/assets/81505421/5f24f24b-fcbf-47a7-942c-c0f59ccdb8d7">

<!-- 없으면 삭제 -->
