### PR TITLE
[QA] response key 변경하여 해결

### DIFF
--- a/src/views/OfferInfoPage/components/ImgModal.tsx
+++ b/src/views/OfferInfoPage/components/ImgModal.tsx
@@ -13,15 +13,14 @@ interface ImgModalProps {
 }
 
 const ImgModal = ({ isModal, onClose, imgUrl }: ImgModalProps) => {
-  console.log(imgUrl);
   const data = usePostDownloadUrlOffer(imgUrl);
 
   const handleImgDownload = () => {
     if (!data) return;
     const a = document.createElement('a');
-    a.href = data.downloadUrl;
+    a.href = data.offerImageUrl;
     a.style.display = 'none';
-    a.download = 'apply_moddy.png';
+    a.download = 'my_moddy.png';
     document.body.appendChild(a);
     a.click();
     a.remove();

--- a/src/views/OfferInfoPage/hooks/type.ts
+++ b/src/views/OfferInfoPage/hooks/type.ts
@@ -55,5 +55,5 @@ export interface OfferInfoProps {
 }
 
 export interface UserGetDownloadUrlOfferProps {
-  downloadUrl: string;
+  offerImageUrl: string;
 }

--- a/src/views/OfferInfoPage/hooks/usePostDownloadUrlOffer.ts
+++ b/src/views/OfferInfoPage/hooks/usePostDownloadUrlOffer.ts
@@ -14,7 +14,6 @@ const usePostDownloadUrlOffer = (imgUrl: string) => {
       const response = await api.post('/designer/offer/download-url', {
         offerImageUrl: imgUrl,
       });
-      console.log(response.data.data);
       setData(response.data.data);
     } catch (err) {
       navigate('/error');


### PR DESCRIPTION
<!-- PR의 제목은 "[QA] 내용 " 으로, 연결되는 이슈 제목과 동일하게 가져가시면 됩니다! -->
![QA](https://github.com/TEAM-MODDY/moddy-web/assets/81505421/3749ec71-89ed-4ccf-9b22-e7912bed83de)

## ▶️ Related Issue

- close #351 

## 🚨 Problem
지원서 이미지를 다운로드 받으면 비어있는 html이 다운로드됨 
<img width="750" alt="스크린샷 2024-01-20 오전 3 04 53" src="https://github.com/TEAM-MODDY/moddy-web/assets/81505421/956f77ac-01cf-4f86-81b5-dedee22241db">

<!-- 발견된 QA 사항 작성 -->

<br />

## 🚑 Solution
나는 Response.downloadUrl로 접근하고 있었고,
서버는 Reponse.offerImageUrl로 주고 있어서 이미지를 못받은 것이었음. 
다시 제대로 접근해서 이미지 다운로드에 성공했다. 


<!-- 어떻게 해결했는지 -->

<br />

## 📸 Screenshot
<img width="156" alt="스크린샷 2024-01-20 오전 3 06 51" src="https://github.com/TEAM-MODDY/moddy-web/assets/81505421/5d935bd5-f1d5-44ef-b36e-73f91fb91bdb">

<!-- 없으면 삭제 -->
