### PR TITLE
[Common] Input 컴포넌트 변경

### DIFF
--- a/src/views/@common/components/Input.tsx
+++ b/src/views/@common/components/Input.tsx
@@ -3,25 +3,56 @@ import { styled } from 'styled-components';
 
 import { IcCheckBlue } from '../assets/icons';
 
+import { REGEX } from '@/views/@common/utils/regex';
+
 interface InputProps {
   placeholderText: string;
+  regex: RegExp;
   initialValue?: string;
+  maxLength?: number;
+  onlyNumber?: boolean;
   onChangeFn: (value: string) => void;
 }
 
-const Input = ({ placeholderText, initialValue, onChangeFn }: InputProps) => {
-  const [name, setName] = useState(initialValue ? initialValue : '');
+const Input = (props: InputProps) => {
+  const {
+    placeholderText,
+    initialValue = '',
+    maxLength,
+    regex = REGEX.NOT_EMPTY,
+    onlyNumber = false,
+    onChangeFn,
+  } = props;
+
+  const [text, setText] = useState(initialValue);
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    let value = e.target.value;
+
+    // 최대 길이 제한이 있는 경우, 입력값을 해당 길이로 제한
+    if (maxLength && value.length > maxLength) {
+      value = value.slice(0, maxLength);
+    }
+
+    // 숫자만 입력해야 할 경우, 숫자가 아닌 문자 입력 방지
+    if (onlyNumber) {
+      value = value.replace(REGEX.ONLY_NUMBER, '');
+    }
+
+    setText(value);
+    onChangeFn(value);
+  };
+
   return (
     <S.InputLayout>
       <S.Input
+        maxLength={maxLength}
         placeholder={placeholderText}
-        value={name}
-        onChange={(e) => {
-          setName(e.target.value);
-          onChangeFn(e.target.value);
-        }}
+        value={text}
+        onChange={handleInputChange}
+        type={onlyNumber ? 'tel' : 'text'}
       />
-      {name !== '' && <IcCheckBlue />}
+      {regex.test(text) && <IcCheckBlue />}
     </S.InputLayout>
   );
 };

--- a/src/views/@common/components/Input.tsx
+++ b/src/views/@common/components/Input.tsx
@@ -7,7 +7,7 @@ import { REGEX } from '@/views/@common/utils/regex';
 
 interface InputProps {
   placeholderText: string;
-  regex: RegExp;
+  regex?: RegExp;
   initialValue?: string;
   maxLength?: number;
   onlyNumber?: boolean;

--- a/src/views/@common/utils/regex.ts
+++ b/src/views/@common/utils/regex.ts
@@ -1,0 +1,4 @@
+export const REGEX = {
+  NOT_EMPTY: /.+/,
+  ONLY_NUMBER: /[^0-9]/g,
+};


### PR DESCRIPTION
<!-- PR의 제목은 "[페이지명] 구현내용 " 으로, 연결되는 이슈 제목과 동일하게 가져가시면 됩니다! -->

![PR](https://github.com/TEAM-MODDY/moddy-web/assets/81505421/2d53d2e3-fcc8-4b65-835a-b118664382be)

## ▶️ Related Issue

- close #359

<br />

## ✅ Done Task
- 정규식에 따른 검증 기능 추가
- 최대 길이 제한 기능 추가
- 숫자만 입력 가능 기능 추가

<br />

## 🔎 PR Point

<!-- 리뷰어에게 나의 코드를 설명해주세요 -->
### 📢 검증이 필요한 경우 regex prop을 추가해주세요
승희님의 의견을 반영하여 regex는 필수 속성이 아닌 선택 속성으로 수정하였고
기본값은 NOT_EMPTY (빈 값이 아닐 때) 입니다. 다른 검증식이 필요하다면 props로 넘겨주세요
클린하게 하기 위해서 regex는 상수화 하면 좋겠죠?

### 📢 LimitInput 으로 구현했던 입력 창 모두 Input으로 바꿔주세요

이 공통 컴포넌트를 리팩한 이유이죠 !! 같은 디자인을 사용하기 때문에 이 Input으로 바꿔주시면 됩니다
`maxLength` prop을 통해 동일하게 사용가능합니다!

### 📢 숫자만 입력가능한 input을 만들어야 할 때, onlyNumber를 prop으로 추가해주세요
추가로, 숫자 입력 옵션 적용시 'tel' 타입의 키패드를 띄워 UX를 개선하였습니다

