### PR TITLE
[MainPage] 분기 처리 로직 개선

### DIFF
--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -31,14 +31,14 @@ const MainPage = () => {
 
   const Contents = {
     [USER_TYPE.GUEST]: {
-      mainContent: GuestContents,
+      mainContent: <GuestContents />,
     },
     [USER_TYPE.DESIGNER]: {
-      mainContent: () => designerData && <DesignerContents data={designerData} setPage={setPage} />,
+      mainContent: <DesignerContents data={designerData} setPage={setPage} />,
       name: designerData?.name,
     },
     [USER_TYPE.MODEL]: {
-      mainContent: () => modelData && <ModelContents data={modelData} setPage={setPage} />,
+      mainContent: <ModelContents data={modelData} setPage={setPage} />,
       applyType: modelData?.status,
       name: modelData?.name,
     },
@@ -51,9 +51,9 @@ const MainPage = () => {
   };
 
   const MainContentsByUserType = () => {
-    const ContentComponent = Contents[userType].mainContent;
-    return <ContentComponent />;
+    return Contents[userType].mainContent;
   };
+
   return (
     <MainPageLayout>
       <StatusBarForiOS />

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -1,5 +1,4 @@
-import { useEffect, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useState } from 'react';
 import { useRecoilValue } from 'recoil';
 import { styled } from 'styled-components';
 
@@ -11,23 +10,16 @@ import { DesignerContents, ModelContents } from '../views/MainPage/components/Us
 
 import { userTypeState } from '@/recoil/atoms/signUpState';
 import { USER_TYPE } from '@/views/@common/constants/userType';
+import UsePreventGoBack from '@/views/@common/utils/UsePreventGoBack';
 import { INITIAL_PAGE } from '@/views/MainPage/constants/constant';
 import useGetMain from '@/views/MainPage/hooks/useGetMain';
 
 const MainPage = () => {
+  UsePreventGoBack();
+
   const userType = useRecoilValue(userTypeState);
   const [page, setPage] = useState(INITIAL_PAGE);
   const { modelData, designerData } = useGetMain({ user: userType, page: page });
-
-  // 뒤로 가기 막기 관련
-  const navigate = useNavigate();
-  useEffect(() => {
-    const handlePopState = () => navigate('/');
-    window.history.pushState(null, '', window.location.href);
-    window.addEventListener('popstate', handlePopState);
-
-    return () => window.removeEventListener('popstate', handlePopState);
-  }, [navigate]);
 
   const Contents = {
     [USER_TYPE.GUEST]: {

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useRecoilValue } from 'recoil';
 import { styled } from 'styled-components';
@@ -7,51 +7,60 @@ import Banner from '../views/MainPage/components/Banner';
 import GuestContents from '../views/MainPage/components/GuestContents';
 import StatusBarForiOS from '../views/MainPage/components/StatusBarForiOS';
 import TopSheet from '../views/MainPage/components/TopSheet';
-import { ReceivedOffer, ReceivedApplication } from '../views/MainPage/components/UserContents';
+import { DesignerContents, ModelContents } from '../views/MainPage/components/UserContents';
 
 import { userTypeState } from '@/recoil/atoms/signUpState';
 import { USER_TYPE } from '@/views/@common/constants/userType';
+import { INITIAL_PAGE } from '@/views/MainPage/constants/constant';
 import useGetMain from '@/views/MainPage/hooks/useGetMain';
 
 const MainPage = () => {
   const userType = useRecoilValue(userTypeState);
+  const [page, setPage] = useState(INITIAL_PAGE);
+  const { modelData, designerData } = useGetMain({ user: userType, page: page });
 
   // 뒤로 가기 막기 관련
   const navigate = useNavigate();
-  window.history.pushState(null, '', '');
-  window.onpopstate = () => {
-    navigate('/');
+  useEffect(() => {
+    const handlePopState = () => navigate('/');
+    window.history.pushState(null, '', window.location.href);
+    window.addEventListener('popstate', handlePopState);
+
+    return () => window.removeEventListener('popstate', handlePopState);
+  }, [navigate]);
+
+  const Contents = {
+    [USER_TYPE.GUEST]: {
+      mainContent: GuestContents,
+    },
+    [USER_TYPE.DESIGNER]: {
+      mainContent: () => designerData && <DesignerContents data={designerData} setPage={setPage} />,
+      name: designerData?.name,
+    },
+    [USER_TYPE.MODEL]: {
+      mainContent: () => modelData && <ModelContents data={modelData} setPage={setPage} />,
+      applyType: modelData?.status,
+      name: modelData?.name,
+    },
   };
 
-  const [page, setPage] = useState(1);
-  const { data } = useGetMain({ user: userType, page: page });
-
-  const MainContents = () => {
-    switch (userType) {
-      case USER_TYPE.GUEST:
-        return <GuestContents />;
-      case USER_TYPE.DESIGNER:
-        return data && <ReceivedApplication data={data} setPage={setPage} />;
-      case USER_TYPE.MODEL:
-        return data && <ReceivedOffer data={data} setPage={setPage} />;
-      default:
-        return null;
-    }
+  const TopSheetProps = {
+    userType,
+    applyType: Contents[userType].applyType,
+    name: Contents[userType].name,
   };
 
+  const MainContentsByUserType = () => {
+    const ContentComponent = Contents[userType].mainContent;
+    return <ContentComponent />;
+  };
   return (
-    <>
-      <MainPageLayout>
-        <StatusBarForiOS />
-        <TopSheet
-          userType={userType}
-          applyType={userType === USER_TYPE.MODEL && data && 'status' in data ? data.status : ''}
-          name={data ? data.name : ''}
-        />
-        <Banner />
-        <MainContents />
-      </MainPageLayout>
-    </>
+    <MainPageLayout>
+      <StatusBarForiOS />
+      <TopSheet {...TopSheetProps} />
+      <Banner />
+      <MainContentsByUserType />
+    </MainPageLayout>
   );
 };
 

--- a/src/views/@common/utils/UsePreventGoBack.ts
+++ b/src/views/@common/utils/UsePreventGoBack.ts
@@ -1,0 +1,15 @@
+import { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+const UsePreventGoBack = () => {
+  const navigate = useNavigate();
+  useEffect(() => {
+    const handlePopState = () => navigate('/');
+    window.history.pushState(null, '', window.location.href);
+    window.addEventListener('popstate', handlePopState);
+
+    return () => window.removeEventListener('popstate', handlePopState);
+  }, [navigate]);
+};
+
+export default UsePreventGoBack;

--- a/src/views/MainPage/components/Card.tsx
+++ b/src/views/MainPage/components/Card.tsx
@@ -2,24 +2,6 @@ import { useNavigate } from 'react-router-dom';
 import { styled } from 'styled-components';
 
 import { ImgNew } from '../assets/images';
-
-interface OfferCardProps {
-  offerId: number;
-  name: string;
-  shopName: string;
-  imgUrl: string;
-  isClicked: boolean;
-  conditions: string[];
-}
-
-interface ApplicationCardProps {
-  applicationId: number;
-  name: string;
-  age: number;
-  imgUrl: string;
-  gender: string;
-  preferHairStyles: string[];
-}
 interface CardProps {
   analyticsId: string;
   id: number;
@@ -56,11 +38,11 @@ const Name = ({ children }: Props) => <S.NameSpan>{children}</S.NameSpan>;
 const Detail = ({ children }: Props) => <S.DetailSpan>{children}</S.DetailSpan>;
 
 const OptionTag = ({ options }: OptionTagProps) => (
-  <S.PreferStyleWrapperBox>
+  <S.OptionWrapperBox>
     {options.map((item, index) => (
-      <S.PreferStyleTagBox key={index}>{item}</S.PreferStyleTagBox>
+      <S.OptionTagBox key={index}>{item}</S.OptionTagBox>
     ))}
-  </S.PreferStyleWrapperBox>
+  </S.OptionWrapperBox>
 );
 
 const NewIcon = () => (
@@ -77,35 +59,6 @@ export const Card = Object.assign(CardMain, {
   Detail,
   OptionTag,
 });
-
-const OfferCard = ({ offerId, name, shopName, imgUrl, isClicked, conditions }: OfferCardProps) => (
-  <Card analyticsId="ga-offer-card" navigateTo="/offer-info" id={offerId}>
-    {!isClicked && <Card.NewIcon />}
-    <Card.ProfileImg imgUrl={imgUrl} alt="제안서 프로필 사진" />
-    <Card.ContentsBox>
-      <S.FlexBox>
-        <Card.Name>{name}</Card.Name>
-        <Card.Detail>{shopName}</Card.Detail>
-      </S.FlexBox>
-      <Card.OptionTag options={conditions} />
-    </Card.ContentsBox>
-  </Card>
-);
-
-const ApplicationCard = ({ applicationId, name, age, imgUrl, gender, preferHairStyles }: ApplicationCardProps) => (
-  <Card analyticsId="ga-application-card" navigateTo="/model-info" id={applicationId}>
-    <Card.ProfileImg imgUrl={imgUrl} alt="지원서 프로필 사진" />
-    <Card.ContentsBox>
-      <S.FlexBox>
-        <Card.Name>{name}</Card.Name>
-        <Card.Detail>{`${age}세 / ${gender}`}</Card.Detail>
-      </S.FlexBox>
-      <Card.OptionTag options={preferHairStyles} />
-    </Card.ContentsBox>
-  </Card>
-);
-
-export { OfferCard, ApplicationCard };
 
 const CardLayout = styled.div`
   flex-grow: 1;
@@ -172,12 +125,12 @@ const DetailSpan = styled.span`
   white-space: nowrap;
 `;
 
-const PreferStyleWrapperBox = styled.div`
+const OptionWrapperBox = styled.div`
   display: flex;
   gap: 0.8rem;
 `;
 
-const PreferStyleTagBox = styled.div`
+const OptionTagBox = styled.div`
   display: flex;
   justify-content: center;
   align-items: center;
@@ -206,7 +159,7 @@ const S = {
   FlexBox,
   NameSpan,
   DetailSpan,
-  PreferStyleWrapperBox,
-  PreferStyleTagBox,
+  OptionWrapperBox,
+  OptionTagBox,
   NewTagBox,
 };

--- a/src/views/MainPage/components/Card.tsx
+++ b/src/views/MainPage/components/Card.tsx
@@ -20,60 +20,96 @@ interface ApplicationCardProps {
   gender: string;
   preferHairStyles: string[];
 }
+interface CardProps {
+  analyticsId: string;
+  id: number;
+  navigateTo: string;
+  children: React.ReactNode;
+}
 
-const OfferCard = (props: OfferCardProps) => {
+const CardMain = ({ analyticsId, navigateTo, id, children }: CardProps) => {
   const navigate = useNavigate();
-  const { offerId, name, shopName, imgUrl, isClicked, conditions } = props;
+
   return (
-    <S.ApplicationCardLayout id="ga-offer-card" onClick={() => navigate('/offer-info', { state: offerId })}>
-      {isClicked ? null : (
-        <S.NewTagBox>
-          <ImgNew />
-        </S.NewTagBox>
-      )}
-      <S.ProfileImageBox $img={imgUrl} title="제안서 프로필 사진" />
-      <S.ModelInfoBox>
-        <S.PersonalInfoBox>
-          <S.NameSpan>{name}</S.NameSpan>
-          <S.AgeGenderSpan>{shopName}</S.AgeGenderSpan>
-        </S.PersonalInfoBox>
-        <S.PreferStyleWrapperBox>
-          {conditions.map((item, index) => (
-            <S.PreferStyleTagBox key={index}>{item}</S.PreferStyleTagBox>
-          ))}
-        </S.PreferStyleWrapperBox>
-      </S.ModelInfoBox>
-    </S.ApplicationCardLayout>
+    <S.CardLayout id={analyticsId} onClick={() => navigate(navigateTo, { state: id })}>
+      {children}
+    </S.CardLayout>
   );
 };
+interface ProfileImgProps {
+  imgUrl: string;
+  alt: string;
+}
+interface Props {
+  children: React.ReactNode;
+}
+interface OptionTagProps {
+  options: string[];
+}
 
-const ApplicationCard = (props: ApplicationCardProps) => {
-  const navigate = useNavigate();
-  const { applicationId, name, age, imgUrl, gender, preferHairStyles } = props;
-  return (
-    <S.ApplicationCardLayout id="ga-application-card" onClick={() => navigate('/model-info', { state: applicationId })}>
-      <S.ProfileImageBox $img={imgUrl} title="지원서 프로필 사진" />
-      <S.ModelInfoBox>
-        <S.PersonalInfoBox>
-          <S.NameSpan>{name}</S.NameSpan>
-          <S.AgeGenderSpan>
-            {age}세 / {gender}
-          </S.AgeGenderSpan>
-        </S.PersonalInfoBox>
-        <S.PreferStyleWrapperBox>
-          {preferHairStyles.map((item, index) => (
-            <S.PreferStyleTagBox key={index}>{item}</S.PreferStyleTagBox>
-          ))}
-        </S.PreferStyleWrapperBox>
-      </S.ModelInfoBox>
-    </S.ApplicationCardLayout>
-  );
-};
+const ProfileImg = ({ imgUrl, alt }: ProfileImgProps) => <S.ProfileImageBox $img={imgUrl} title={alt} />;
+
+const ContentsBox = ({ children }: Props) => <S.InfoBox>{children}</S.InfoBox>;
+
+const Name = ({ children }: Props) => <S.NameSpan>{children}</S.NameSpan>;
+
+const Detail = ({ children }: Props) => <S.DetailSpan>{children}</S.DetailSpan>;
+
+const OptionTag = ({ options }: OptionTagProps) => (
+  <S.PreferStyleWrapperBox>
+    {options.map((item, index) => (
+      <S.PreferStyleTagBox key={index}>{item}</S.PreferStyleTagBox>
+    ))}
+  </S.PreferStyleWrapperBox>
+);
+
+const NewIcon = () => (
+  <S.NewTagBox>
+    <ImgNew />
+  </S.NewTagBox>
+);
+
+export const Card = Object.assign(CardMain, {
+  NewIcon,
+  ProfileImg,
+  ContentsBox,
+  Name,
+  Detail,
+  OptionTag,
+});
+
+const OfferCard = ({ offerId, name, shopName, imgUrl, isClicked, conditions }: OfferCardProps) => (
+  <Card analyticsId="ga-offer-card" navigateTo="/offer-info" id={offerId}>
+    {!isClicked && <Card.NewIcon />}
+    <Card.ProfileImg imgUrl={imgUrl} alt="제안서 프로필 사진" />
+    <Card.ContentsBox>
+      <S.FlexBox>
+        <Card.Name>{name}</Card.Name>
+        <Card.Detail>{shopName}</Card.Detail>
+      </S.FlexBox>
+      <Card.OptionTag options={conditions} />
+    </Card.ContentsBox>
+  </Card>
+);
+
+const ApplicationCard = ({ applicationId, name, age, imgUrl, gender, preferHairStyles }: ApplicationCardProps) => (
+  <Card analyticsId="ga-application-card" navigateTo="/model-info" id={applicationId}>
+    <Card.ProfileImg imgUrl={imgUrl} alt="지원서 프로필 사진" />
+    <Card.ContentsBox>
+      <S.FlexBox>
+        <Card.Name>{name}</Card.Name>
+        <Card.Detail>{`${age}세 / ${gender}`}</Card.Detail>
+      </S.FlexBox>
+      <Card.OptionTag options={preferHairStyles} />
+    </Card.ContentsBox>
+  </Card>
+);
 
 export { OfferCard, ApplicationCard };
 
-const ApplicationCardLayout = styled.button`
+const CardLayout = styled.div`
   flex-grow: 1;
+  overflow: hidden;
   position: relative;
 
   max-width: calc(100% / 2 - 0.75rem);
@@ -81,6 +117,8 @@ const ApplicationCardLayout = styled.button`
   border-radius: 12px;
 
   box-shadow: ${({ theme }) => theme.effects.shadow1};
+
+  cursor: pointer;
 `;
 
 const ProfileImageBox = styled.div<{ $img: string }>`
@@ -97,7 +135,7 @@ const ProfileImageBox = styled.div<{ $img: string }>`
   }
 `;
 
-const ModelInfoBox = styled.div`
+const InfoBox = styled.div`
   display: flex;
   flex-direction: column;
   gap: 0.4rem;
@@ -105,7 +143,7 @@ const ModelInfoBox = styled.div`
   padding: 0.8rem 1.5rem;
 `;
 
-const PersonalInfoBox = styled.div`
+const FlexBox = styled.div`
   display: flex;
   gap: 0.8rem;
   align-items: center;
@@ -120,7 +158,7 @@ const NameSpan = styled.span`
   white-space: nowrap;
 `;
 
-const AgeGenderSpan = styled.span`
+const DetailSpan = styled.span`
   overflow: hidden;
 
   width: 6.5rem;
@@ -162,12 +200,12 @@ const NewTagBox = styled.div`
   right: 1.2rem;
 `;
 const S = {
-  ApplicationCardLayout,
+  CardLayout,
   ProfileImageBox,
-  ModelInfoBox,
-  PersonalInfoBox,
+  InfoBox,
+  FlexBox,
   NameSpan,
-  AgeGenderSpan,
+  DetailSpan,
   PreferStyleWrapperBox,
   PreferStyleTagBox,
   NewTagBox,

--- a/src/views/MainPage/components/Card.tsx
+++ b/src/views/MainPage/components/Card.tsx
@@ -62,7 +62,6 @@ export const Card = Object.assign(CardMain, {
 
 const CardLayout = styled.div`
   flex-grow: 1;
-  overflow: hidden;
   position: relative;
 
   max-width: calc(100% / 2 - 0.75rem);
@@ -70,8 +69,6 @@ const CardLayout = styled.div`
   border-radius: 12px;
 
   box-shadow: ${({ theme }) => theme.effects.shadow1};
-
-  cursor: pointer;
 `;
 
 const ProfileImageBox = styled.div<{ $img: string }>`

--- a/src/views/MainPage/components/TopSheet.tsx
+++ b/src/views/MainPage/components/TopSheet.tsx
@@ -8,8 +8,8 @@ import { USER_TYPE } from '@/views/@common/constants/userType';
 
 interface TopSheetProps {
   userType: string;
-  applyType: string;
-  name: string;
+  applyType?: string;
+  name?: string;
 }
 
 const TopSheet = (props: TopSheetProps) => {
@@ -17,7 +17,7 @@ const TopSheet = (props: TopSheetProps) => {
   const navigate = useNavigate();
 
   const OnBoardingText = () => {
-    if (!userType) {
+    if (userType === USER_TYPE.GUEST) {
       return (
         <S.OnBoardingParagraph>
           헤어 디자이너와 모델,
@@ -56,37 +56,39 @@ const TopSheet = (props: TopSheetProps) => {
       }
     }
   };
+
+  const LoginButton = () => (
+    <S.LoginButton id="ga-top-login-btn" type="button" onClick={() => navigate('/login')}>
+      <S.LoginSpan>로그인하기</S.LoginSpan>
+      <IcRightWhite />
+    </S.LoginButton>
+  );
+
+  const MyPageButton = () => (
+    <button type="button" onClick={() => navigate('/my-page')}>
+      <IcModdyuser />
+    </button>
+  );
+  const StartButton = () => (
+    <S.StartButton
+      id={userType === USER_TYPE.GUEST ? 'ga-login-btn' : 'ga-application-btn'}
+      type="button"
+      onClick={() => navigate(userType === USER_TYPE.GUEST ? '/login' : '/application')}>
+      <S.StartButtonSpan>헤어 모델 지원하기{userType === USER_TYPE.GUEST && ' / 제안하기'}</S.StartButtonSpan>
+      <IcRightWhite />
+    </S.StartButton>
+  );
+
   return (
     <S.TopSheetLayout>
       <S.HeaderBox>
         <IcLogoHome />
-        {!userType ? (
-          <S.LoginButton id="ga-top-login-btn" type="button" onClick={() => navigate('/login')}>
-            <S.LoginSpan>로그인하기</S.LoginSpan>
-            <IcRightWhite />
-          </S.LoginButton>
-        ) : (
-          <button type="button" onClick={() => navigate('/my-page')}>
-            <IcModdyuser />
-          </button>
-        )}
+        {userType === USER_TYPE.GUEST ? <LoginButton /> : <MyPageButton />}
       </S.HeaderBox>
       <S.OnBoardingBox>
         <OnBoardingText />
       </S.OnBoardingBox>
-      {userType !== USER_TYPE.DESIGNER ? (
-        userType === USER_TYPE.GUEST ? (
-          <S.StartButton id="ga-login-btn" type="button" onClick={() => navigate('/login')}>
-            <S.StartButtonSpan>헤어 모델 지원하기 / 제안하기</S.StartButtonSpan>
-            <IcRightWhite />
-          </S.StartButton>
-        ) : (
-          <S.StartButton id="ga-application-btn" type="button" onClick={() => navigate('/application')}>
-            <S.StartButtonSpan>헤어 모델 지원하기</S.StartButtonSpan>
-            <IcRightWhite />
-          </S.StartButton>
-        )
-      ) : null}
+      {userType !== USER_TYPE.DESIGNER && <StartButton />}
     </S.TopSheetLayout>
   );
 };

--- a/src/views/MainPage/components/UserContents.tsx
+++ b/src/views/MainPage/components/UserContents.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import React, { useEffect } from 'react';
 import { useInView } from 'react-intersection-observer';
 import { styled } from 'styled-components';
 
@@ -7,85 +7,91 @@ import { DesignerResponse, ModelResponse } from '../hooks/type';
 
 import { OfferCard, ApplicationCard } from './Card';
 
-interface UserContentsProps {
-  data: DesignerResponse | ModelResponse;
+interface DesignerContentsProps {
+  data: DesignerResponse;
+  setPage: React.Dispatch<React.SetStateAction<number>>;
+}
+interface ModelContentsProps {
+  data: ModelResponse;
   setPage: React.Dispatch<React.SetStateAction<number>>;
 }
 
-const ReceivedOffer = (props: UserContentsProps) => {
-  const { data, setPage } = props;
+interface UserContentsProps {
+  title: string;
+  children: React.ReactNode;
+  ref: React.LegacyRef<HTMLDivElement>;
+  dataLength: number;
+  total: number;
+}
+
+interface UserContentsProps {
+  title: string;
+  children: React.ReactNode;
+  dataLength: number;
+  total: number;
+}
+
+const UserContents = React.forwardRef<HTMLDivElement, UserContentsProps>(
+  ({ title, children, dataLength, total }, ref) => (
+    <S.UserContentsLayout>
+      <S.TitleSpan>{title}</S.TitleSpan>
+      <S.ContentsBox>{children}</S.ContentsBox>
+      {dataLength < total && <div ref={ref}></div>}
+    </S.UserContentsLayout>
+  ),
+);
+UserContents.displayName = 'UserContents';
+
+const usePagination = (setPage: React.Dispatch<React.SetStateAction<number>>) => {
   const [ref, inView] = useInView();
 
   useEffect(() => {
-    inView && setPage((prev) => prev + 1);
-  }, [inView]);
+    if (inView) setPage((prev) => prev + 1);
+  }, [inView, setPage]);
+
+  return ref;
+};
+
+const ModelContents = ({ data, setPage }: ModelContentsProps) => {
+  const ref = usePagination(setPage);
+
+  const renderOffers = () => data.offers.map((offer, index) => <OfferCard key={index} {...offer} />);
+
+  const renderEmptyState = () => (
+    <S.EmptyBox>
+      <S.HelperTextSpan>
+        {data.status === APPLY_STATUS.NOTHING ? (
+          '지금 바로 헤어모델에 지원해 보세요 :)'
+        ) : (
+          <S.LineHeightSpan>
+            조금만 기다리면 <br /> 디자이너의 모델 제안을 문자로 보내드릴게요 :)
+          </S.LineHeightSpan>
+        )}
+      </S.HelperTextSpan>
+    </S.EmptyBox>
+  );
 
   return (
-    <S.UserContentsLayout>
-      <S.TitleSpan>도착한 제안서</S.TitleSpan>
-      {'status' in data && data.status === APPLY_STATUS.RECEIVED ? (
-        <S.ContentsBox>
-          {data.offers.map((offer, index) => (
-            <OfferCard
-              key={index}
-              offerId={offer.offerId}
-              name={offer.name}
-              shopName={offer.shopName}
-              imgUrl={offer.imgUrl}
-              isClicked={offer.isClicked}
-              conditions={offer.conditions}
-            />
-          ))}
-        </S.ContentsBox>
-      ) : (
-        <S.EmptyBox>
-          <S.HelperTextSpan>
-            {'status' in data && data.status === APPLY_STATUS.NOTHING ? (
-              '지금 바로 헤어모델에 지원해 보세요 :)'
-            ) : (
-              <S.LineHeightSpan>
-                조금만 기다리면 <br /> 디자이너의 모델 제안을 문자로 보내드릴게요 :&#41;
-              </S.LineHeightSpan>
-            )}
-          </S.HelperTextSpan>
-        </S.EmptyBox>
-      )}
-      {'offers' in data && data.offers.length < data.total && <div ref={ref}></div>}
-    </S.UserContentsLayout>
+    <UserContents title="도착한 제안서" ref={ref} dataLength={data.offers.length} total={data.total}>
+      {data.status === APPLY_STATUS.RECEIVED ? renderOffers() : renderEmptyState()}
+    </UserContents>
   );
 };
 
-const ReceivedApplication = (props: UserContentsProps) => {
-  const { data, setPage } = props;
-  const [ref, inView] = useInView();
+const DesignerContents = ({ data, setPage }: DesignerContentsProps) => {
+  const ref = usePagination(setPage);
 
-  useEffect(() => {
-    inView && setPage((prev) => prev + 1);
-  }, [inView]);
+  const renderApplications = () =>
+    data.hairModelApplications.map((application, index) => <ApplicationCard key={index} {...application} />);
 
   return (
-    <S.UserContentsLayout>
-      <S.TitleSpan>도착한 지원서</S.TitleSpan>
-      <S.ContentsBox>
-        {'hairModelApplications' in data &&
-          data.hairModelApplications.map((application, index) => (
-            <ApplicationCard
-              key={index}
-              applicationId={application.applicationId}
-              name={application.name}
-              age={application.age}
-              imgUrl={application.imgUrl}
-              gender={application.gender}
-              preferHairStyles={application.preferHairStyles}
-            />
-          ))}
-      </S.ContentsBox>
-      {'hairModelApplications' in data && data.hairModelApplications.length < data.total && <div ref={ref}></div>}
-    </S.UserContentsLayout>
+    <UserContents title="도착한 지원서" ref={ref} dataLength={data.hairModelApplications.length} total={data.total}>
+      {renderApplications()}
+    </UserContents>
   );
 };
 
-export { ReceivedOffer, ReceivedApplication };
+export { ModelContents, DesignerContents };
 
 const UserContentsLayout = styled.div`
   padding: 0 1.6rem 4rem;
@@ -101,8 +107,8 @@ const EmptyBox = styled.div`
   justify-content: center;
   align-items: center;
 
+  width: 100%;
   height: 20rem;
-  margin-top: 1.2rem;
   border: 1px dashed ${({ theme }) => theme.colors.moddy_gray20};
   border-radius: 10px;
 

--- a/src/views/MainPage/components/UserContents.tsx
+++ b/src/views/MainPage/components/UserContents.tsx
@@ -8,11 +8,11 @@ import { DesignerResponse, ModelResponse } from '../hooks/type';
 import { Card } from './Card';
 
 interface DesignerContentsProps {
-  data: DesignerResponse;
+  data: DesignerResponse | undefined;
   setPage: React.Dispatch<React.SetStateAction<number>>;
 }
 interface ModelContentsProps {
-  data: ModelResponse;
+  data: ModelResponse | undefined;
   setPage: React.Dispatch<React.SetStateAction<number>>;
 }
 
@@ -55,6 +55,8 @@ const usePagination = (setPage: React.Dispatch<React.SetStateAction<number>>) =>
 const ModelContents = ({ data, setPage }: ModelContentsProps) => {
   const ref = usePagination(setPage);
 
+  if (!data) return;
+
   const renderOffers = () =>
     data.offers.map((offer, index) => (
       <Card analyticsId="ga-offer-card" navigateTo="/offer-info" id={offer.offerId} key={index}>
@@ -93,6 +95,8 @@ const ModelContents = ({ data, setPage }: ModelContentsProps) => {
 
 const DesignerContents = ({ data, setPage }: DesignerContentsProps) => {
   const ref = usePagination(setPage);
+
+  if (!data) return;
 
   const renderApplications = () =>
     data.hairModelApplications.map((application, index) => (

--- a/src/views/MainPage/components/UserContents.tsx
+++ b/src/views/MainPage/components/UserContents.tsx
@@ -5,7 +5,7 @@ import { styled } from 'styled-components';
 import { APPLY_STATUS } from '../constants/applyStatus';
 import { DesignerResponse, ModelResponse } from '../hooks/type';
 
-import { OfferCard, ApplicationCard } from './Card';
+import { Card } from './Card';
 
 interface DesignerContentsProps {
   data: DesignerResponse;
@@ -55,9 +55,22 @@ const usePagination = (setPage: React.Dispatch<React.SetStateAction<number>>) =>
 const ModelContents = ({ data, setPage }: ModelContentsProps) => {
   const ref = usePagination(setPage);
 
-  const renderOffers = () => data.offers.map((offer, index) => <OfferCard key={index} {...offer} />);
+  const renderOffers = () =>
+    data.offers.map((offer, index) => (
+      <Card analyticsId="ga-offer-card" navigateTo="/offer-info" id={offer.offerId} key={index}>
+        {!offer.isClicked && <Card.NewIcon />}
+        <Card.ProfileImg imgUrl={offer.imgUrl} alt="제안서 프로필 사진" />
+        <Card.ContentsBox>
+          <S.FlexBox>
+            <Card.Name>{offer.name}</Card.Name>
+            <Card.Detail>{offer.shopName}</Card.Detail>
+          </S.FlexBox>
+          <Card.OptionTag options={offer.conditions} />
+        </Card.ContentsBox>
+      </Card>
+    ));
 
-  const renderEmptyState = () => (
+  const renderEmptyBox = () => (
     <S.EmptyBox>
       <S.HelperTextSpan>
         {data.status === APPLY_STATUS.NOTHING ? (
@@ -73,7 +86,7 @@ const ModelContents = ({ data, setPage }: ModelContentsProps) => {
 
   return (
     <UserContents title="도착한 제안서" ref={ref} dataLength={data.offers.length} total={data.total}>
-      {data.status === APPLY_STATUS.RECEIVED ? renderOffers() : renderEmptyState()}
+      {data.status === APPLY_STATUS.RECEIVED ? renderOffers() : renderEmptyBox()}
     </UserContents>
   );
 };
@@ -82,7 +95,18 @@ const DesignerContents = ({ data, setPage }: DesignerContentsProps) => {
   const ref = usePagination(setPage);
 
   const renderApplications = () =>
-    data.hairModelApplications.map((application, index) => <ApplicationCard key={index} {...application} />);
+    data.hairModelApplications.map((application, index) => (
+      <Card analyticsId="ga-application-card" navigateTo="/model-info" id={application.applicationId} key={index}>
+        <Card.ProfileImg imgUrl={application.imgUrl} alt="지원서 프로필 사진" />
+        <Card.ContentsBox>
+          <S.FlexBox>
+            <Card.Name>{application.name}</Card.Name>
+            <Card.Detail>{`${application.age}세 / ${application.gender}`}</Card.Detail>
+          </S.FlexBox>
+          <Card.OptionTag options={application.preferHairStyles} />
+        </Card.ContentsBox>
+      </Card>
+    ));
 
   return (
     <UserContents title="도착한 지원서" ref={ref} dataLength={data.hairModelApplications.length} total={data.total}>
@@ -133,6 +157,13 @@ const ContentsBox = styled.div`
   width: 100%;
   margin-top: 1.2rem;
 `;
+
+const FlexBox = styled.div`
+  display: flex;
+  gap: 0.8rem;
+  align-items: center;
+`;
+
 const S = {
   UserContentsLayout,
   EmptyBox,
@@ -140,4 +171,5 @@ const S = {
   HelperTextSpan,
   ContentsBox,
   LineHeightSpan,
+  FlexBox,
 };

--- a/src/views/MainPage/constants/constant.ts
+++ b/src/views/MainPage/constants/constant.ts
@@ -1,0 +1,1 @@
+export const INITIAL_PAGE = 1;

--- a/src/views/MainPage/hooks/useGetMain.ts
+++ b/src/views/MainPage/hooks/useGetMain.ts
@@ -13,31 +13,25 @@ interface UseGetModelProps {
 }
 
 const useGetMain = ({ user, page }: UseGetModelProps) => {
-  const [data, setData] = useState<ModelResponse | DesignerResponse>();
+  const [modelData, setModelData] = useState<ModelResponse>();
+  const [designerData, setDesignerData] = useState<DesignerResponse>();
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<AxiosError>();
 
   const fetchData = async () => {
     try {
       const res = await api.get(`/${user}?page=${page}&size=4`);
-      setData((prev) => {
-        // 타입 가드: prev가 ModelResponse 타입인지 확인
-        if (prev && 'offers' in prev) {
-          return {
-            ...res.data.data,
-            offers: [...prev.offers, ...res.data.data.offers],
-          };
-        } else if (prev && 'hairModelApplications' in prev) {
-          // 타입 가드: prev가 DesignerResponse 타입인지 확인
-          return {
-            ...res.data.data,
-            hairModelApplications: [...prev.hairModelApplications, ...res.data.data.hairModelApplications],
-          };
-        } else {
-          // prev가 undefined이거나 해당 속성이 없는 경우
-          return res.data.data;
-        }
-      });
+      if (user === USER_TYPE.MODEL) {
+        setModelData((prev) => ({
+          ...res.data.data,
+          offers: [...(prev?.offers || []), ...res.data.data.offers],
+        }));
+      } else if (user === USER_TYPE.DESIGNER) {
+        setDesignerData((prev) => ({
+          ...res.data.data,
+          hairModelApplications: [...(prev?.hairModelApplications || []), ...res.data.data.hairModelApplications],
+        }));
+      }
     } catch (err) {
       if (err instanceof AxiosError) setError(err);
       removeToken();
@@ -52,7 +46,8 @@ const useGetMain = ({ user, page }: UseGetModelProps) => {
   }, [page]);
 
   return {
-    data,
+    modelData,
+    designerData,
     error,
     loading,
   };


### PR DESCRIPTION
<!-- PR의 제목은 "[페이지명] 구현내용 " 으로, 연결되는 이슈 제목과 동일하게 가져가시면 됩니다! -->

![PR](https://github.com/TEAM-MODDY/moddy-web/assets/81505421/2d53d2e3-fcc8-4b65-835a-b118664382be)

## ▶️ Related Issue

- close #362 

<br />

## ✅ Done Task
- 뒤로 가기 막기 로직 개선 
- 가독성을 위해 메인페이지 분기를 컴포넌트 매핑으로 처리
- 재사용성을 위한 카드 컴포넌트에 합성 컴포넌트 패턴 적용
- 탑시트안의 컴포넌트 추상화
- ReceivedOffer & ApplicationOffer 를 GuestContents와의 네이밍 통일을 위해 변경 (ModelContents, DesignerContents)
- 메인 서버 통신 로직 데이터 분리를 통한 분기 로직 개선

<br />

## 🔎 PR Point

### 1. MainPage.tsx
**변경 전**
```jsx
const MainContents = () => {
    switch (userType) {
      case USER_TYPE.GUEST:
        return <GuestContents />;
      case USER_TYPE.DESIGNER:
        return designerData && <DesignerContents data={designerData} setPage={setPage} />;
      case USER_TYPE.MODEL:
        return modelData && <ModelContents data={modelData} setPage={setPage} />;
      default:
        return null;
    }
  };

  return (
    <MainPageLayout>
      <TopSheet
        userType={userType}
        applyType={userType === USER_TYPE.MODEL && modelData ? modelData.status : ''}
        name={data ? data.name : ''}
      />
      <MainContents />
    </MainPageLayout>
  );
```
**변경 후**
```jsx
  const Contents = {
    [USER_TYPE.GUEST]: {
      mainContent: GuestContents,
    },
    [USER_TYPE.DESIGNER]: {
      mainContent: () => designerData && <DesignerContents data={designerData} setPage={setPage} />,
      name: designerData?.name,
    },
    [USER_TYPE.MODEL]: {
      mainContent: () => modelData && <ModelContents data={modelData} setPage={setPage} />,
      applyType: modelData?.status,
      name: modelData?.name,
    },
  };
  ...
  return (
    <MainPageLayout>
      <TopSheet {...TopSheetProps} />
      <MainContentsByUserType />
    </MainPageLayout>
  );
};
```
코드의 **가독성**을 높이기 위해 기존에 switch문과 삼항 연산자를 이용하여 처리하였 던 것을 유저 유형 별로 필요한 props, 컴포넌트를 객체로 묶어 매핑해주었습니다 (위의 코드에서는 조금 생략되었으니 자세한 사항은 전체 변경 코드를 참고해주세요!)

✋🏻✋🏻✋🏻 **그런데 여기서 고민되는 부분이 있습니다**

**1. return문을 깔끔하게 갈 것이냐**

```jsx
const Contents = {
  [USER_TYPE.GUEST]: {
    mainContent: GuestContents,
  },
  [USER_TYPE.DESIGNER]: {
    mainContent: () => designerData && <DesignerContents data={designerData} setPage={setPage} />,
    name: designerData?.name,
  },
  [USER_TYPE.MODEL]: {
    mainContent: () => modelData && <ModelContents data={modelData} setPage={setPage} />,
    applyType: modelData?.status,
    name: modelData?.name,
  },
};

return (
  <MainPageLayout>
    <StatusBarForiOS />
    <TopSheet {...TopSheetProps} />
    <Banner />
    <MainContentsByUserType />
  </MainPageLayout>
);
```

**2. Contents부분을 깔끔하게 갈것이냐**

```jsx
const Contents = {
    [USER_TYPE.GUEST]: {
      mainContent: GuestContents,
    },
    [USER_TYPE.DESIGNER]: {
      mainContent: DesignerContents,
      name: designerData?.name,
    },
    [USER_TYPE.MODEL]: {
      mainContent: ModelContents,
      applyType: modelData?.status,
      name: modelData?.name,
    },
  };

  return (
    <MainPageLayout>
      <StatusBarForiOS />
      <TopSheet {...TopSheetProps} />
      <Banner />
      {MainContentComponent && <MainContentComponent data={userType !== USER_TYPE.GUEST ? (userType === USER_TYPE.DESIGNER ? designerData : modelData) : undefined} setPage={setPage} />}
    </MainPageLayout>
  );
};
```
가독성에 신경쓰고 있는데 타입에러 때문에 어딘가에는 꼭 조건부가 들어가야하네요 ㅜㅜ
이외에도 다른 로직이나 의견 주시면 감사합니다! 

### 2. Card.tsx
**변경 전**
```jsx
<S.ApplicationCardLayout id="ga-offer-card" onClick={() => navigate('/offer-info', { state: offerId })}>
      {isClicked ? null : (
        <S.NewTagBox>
          <ImgNew />
        </S.NewTagBox>
      )}
      <S.ProfileImageBox $img={imgUrl} title="제안서 프로필 사진" />
      <S.ModelInfoBox>
        <S.PersonalInfoBox>
          <S.NameSpan>{name}</S.NameSpan>
          <S.AgeGenderSpan>{shopName}</S.AgeGenderSpan>
        </S.PersonalInfoBox>
        <S.PreferStyleWrapperBox>
          {conditions.map((item, index) => (
            <S.PreferStyleTagBox key={index}>{item}</S.PreferStyleTagBox>
          ))}
        </S.PreferStyleWrapperBox>
      </S.ModelInfoBox>
    </S.ApplicationCardLayout>
```
**변경 후**
```jsx
<Card analyticsId="ga-application-card" navigateTo="/model-info" id={applicationId}>
    <Card.ProfileImg imgUrl={imgUrl} alt="지원서 프로필 사진" />
    <Card.ContentsBox>
      <S.FlexBox>
        <Card.Name>{name}</Card.Name>
        <Card.Detail>{`${age}세 / ${gender}`}</Card.Detail>
      </S.FlexBox>
      <Card.OptionTag options={preferHairStyles} />
    </Card.ContentsBox>
</Card>
```
재사용성을 위해 합성컴포넌트 패턴을 적용해보았습니다. 자세한 내용은 오늘 미미나에서 다룰게요 !! 
Card 이외에, UserContents에도 적용했보았습니다!

### 3. UseGetMain.ts
**변경 전**
```jsx
const useGetMain = ({ user, page }: UseGetModelProps) => {
  const [data, setData] = useState<ModelResponse | DesignerResponse>();

  const fetchData = async () => {
    try {
      const res = await api.get(`/${user}?page=${page}&size=4`);
      setData((prev) => {
        // 타입 가드: prev가 ModelResponse 타입인지 확인
        if (prev && 'offers' in prev) {
          return {
            ...res.data.data,
            offers: [...prev.offers, ...res.data.data.offers],
          };
        } else if (prev && 'hairModelApplications' in prev) {
          // 타입 가드: prev가 DesignerResponse 타입인지 확인
          return {
            ...res.data.data,
            hairModelApplications: [...prev.hairModelApplications, ...res.data.data.hairModelApplications],
          };
        } else {
          // prev가 undefined이거나 해당 속성이 없는 경우
          return res.data.data;
        }
      });
    }
   ...
```
**변경 후**
```jsx
const useGetMain = ({ user, page }: UseGetModelProps) => {
  const [modelData, setModelData] = useState<ModelResponse>();
  const [designerData, setDesignerData] = useState<DesignerResponse>();

  const fetchData = async () => {
    try {
      const res = await api.get(`/${user}?page=${page}&size=4`);
      if (user === USER_TYPE.MODEL) {
        setModelData((prev) => ({
          ...res.data.data,
          offers: [...(prev?.offers || []), ...res.data.data.offers],
        }));
      } else if (user === USER_TYPE.DESIGNER) {
        setDesignerData((prev) => ({
          ...res.data.data,
          hairModelApplications: [...(prev?.hairModelApplications || []), ...res.data.data.hairModelApplications],
        }));
      }
    }
```
기존 data 안에 조건에 따라 넣어 주려고 해서 가독성이나 타입 사용 측면에서 좋지 않았던 서버 통신 로직을 modelData, designerData로 나누어 처리하였습니다. usertype에 따라 offers와 hairModelApplications만 따로 처리하여 문제를 해결하였습니다
<br />

## 🧨 Trouble Shooting

**🚨 `ref` is not a prop. Trying to access it will result in `undefined` being returned. If you need to access the same value within the child component, you should pass it as a different prop.**

React에서 일반적으로 사용할 수 없는 prop이 몇 가지 있다. 그 중 ref prop도 HTML Element 접근이라는 특수한 용도로 사용되기 때문에 일반적인 prop으로 사용할 수 없다. **ref를 자식 컴포넌트에 전달하려면 React.forwardRef API를 사용해야한다.**
또한 DevTools에 'ForwardRef'로 나타나는데 displayName 속성을 통해 설정할 수 있다

참고 : https://ko.legacy.reactjs.org/docs/forwarding-refs.html