### PR TITLE
[ApplicationPage] 머리 스타일 기본 정보 상태 관리 리팩토링 

### DIFF
--- a/src/recoil/atoms/applicationState.ts
+++ b/src/recoil/atoms/applicationState.ts
@@ -16,7 +16,6 @@ export const applyStepState = atom<applyStepType>({
 export interface hairStyleType {
   length: string;
   preference: Array<string>;
-  lengthStatus: Array<boolean>;
   verifyStatus: boolean;
 }
 
@@ -25,7 +24,6 @@ export const hairStyleState = atom<hairStyleType>({
   default: {
     length: '',
     preference: [],
-    lengthStatus: [false, false, false, false],
     verifyStatus: false,
   },
 });

--- a/src/views/ApplicationPage/components/DefaultInfo.tsx
+++ b/src/views/ApplicationPage/components/DefaultInfo.tsx
@@ -54,7 +54,7 @@ const DefaultInfo = () => {
             </S.Title>
             <S.HairTypeInputBox>
               {SELECT_LENGTH.map((element) => (
-                <HairTypeInput key={element} type={element} />
+                <HairTypeInput key={element.LENGTH} type={element.LENGTH} />
               ))}
             </S.HairTypeInputBox>
           </S.HairLengthSection>

--- a/src/views/ApplicationPage/components/DefaultInfo.tsx
+++ b/src/views/ApplicationPage/components/DefaultInfo.tsx
@@ -18,17 +18,16 @@ import { applyStepState, hairStyleState } from '@/recoil/atoms/applicationState'
 const DefaultInfo = () => {
   const [step, setStep] = useRecoilState(applyStepState);
   const [selectedStyle, setSelectedStyle] = useRecoilState(hairStyleState);
-  const { length, preference, verifyStatus } = selectedStyle;
   const navigate = useNavigate();
 
   useEffect(() => {
-    length && preference.length > 0
+    selectedStyle.length && selectedStyle.preference.length > 0
       ? setSelectedStyle({ ...selectedStyle, verifyStatus: true })
       : setSelectedStyle({ ...selectedStyle, verifyStatus: false });
-  }, [length, preference]);
+  }, [selectedStyle.length, selectedStyle.preference]);
 
   const activateCheckbox = (type: string): boolean => {
-    return preference.includes(type);
+    return selectedStyle.preference.includes(type);
   };
 
   return (
@@ -88,7 +87,7 @@ const DefaultInfo = () => {
           setStep({ ...step, current: step.current + 1 });
         }}
         isFixed={true}
-        disabled={!verifyStatus}
+        disabled={!selectedStyle.verifyStatus}
       />
     </S.DefaultInfoLayout>
   );

--- a/src/views/ApplicationPage/components/DefaultInfo.tsx
+++ b/src/views/ApplicationPage/components/DefaultInfo.tsx
@@ -8,7 +8,7 @@ import Button from '../../@common/components/Button';
 import Header from '../../@common/components/Header';
 import ProgressBar from '../../@common/components/ProgressBar';
 import { INFO_MESSAGE } from '../constants/message';
-import { SELECT_TYPE } from '../constants/select';
+import { SELECT_LENGTH, SELECT_TYPE } from '../constants/select';
 
 import HairTypeInput from './HairTypeInput';
 import StyleButton from './StyleButton';
@@ -53,10 +53,9 @@ const DefaultInfo = () => {
               <span>{INFO_MESSAGE.LENGTH_SUBTITLE}</span>
             </S.Title>
             <S.HairTypeInputBox>
-              <HairTypeInput imgIdx={0} type="SHORT" />
-              <HairTypeInput imgIdx={1} type="ABOVE_SHOULDER" />
-              <HairTypeInput imgIdx={2} type="UNDER_SHOULDER" />
-              <HairTypeInput imgIdx={3} type="UNDER_WAIST" />
+              {SELECT_LENGTH.map((element, index) => (
+                <HairTypeInput key={element} imgIdx={index} type={element} />
+              ))}
             </S.HairTypeInputBox>
           </S.HairLengthSection>
           <hr />

--- a/src/views/ApplicationPage/components/DefaultInfo.tsx
+++ b/src/views/ApplicationPage/components/DefaultInfo.tsx
@@ -53,8 +53,8 @@ const DefaultInfo = () => {
               <span>{INFO_MESSAGE.LENGTH_SUBTITLE}</span>
             </S.Title>
             <S.HairTypeInputBox>
-              {SELECT_LENGTH.map((element, index) => (
-                <HairTypeInput key={element} imgIdx={index} type={element} />
+              {SELECT_LENGTH.map((element) => (
+                <HairTypeInput key={element} type={element} />
               ))}
             </S.HairTypeInputBox>
           </S.HairLengthSection>

--- a/src/views/ApplicationPage/components/DefaultInfo.tsx
+++ b/src/views/ApplicationPage/components/DefaultInfo.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import React, { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useRecoilState } from 'recoil';
 import { styled } from 'styled-components';
@@ -67,8 +67,8 @@ const DefaultInfo = () => {
               <span>{INFO_MESSAGE.PREFERENCE_SUBTITLE}</span>
             </S.Title>
             {SELECT_STYLE.map((element, index) => (
-              <>
-                <S.StyleBox key={element.TITLE}>
+              <React.Fragment key={element.TITLE}>
+                <S.StyleBox>
                   <h3>{element.TITLE}</h3>
                   <S.SelectList>
                     {Object.keys(element.CONTENT).map((content) => (
@@ -77,7 +77,7 @@ const DefaultInfo = () => {
                   </S.SelectList>
                 </S.StyleBox>
                 {index === SELECT_STYLE.length - 1 ? null : <hr />}
-              </>
+              </React.Fragment>
             ))}
           </S.DeserveStyleSection>
         </S.StyleSection>

--- a/src/views/ApplicationPage/components/DefaultInfo.tsx
+++ b/src/views/ApplicationPage/components/DefaultInfo.tsx
@@ -8,7 +8,7 @@ import Button from '../../@common/components/Button';
 import Header from '../../@common/components/Header';
 import ProgressBar from '../../@common/components/ProgressBar';
 import { INFO_MESSAGE } from '../constants/message';
-import { SELECT_LENGTH, SELECT_TYPE } from '../constants/select';
+import { SELECT_LENGTH, SELECT_STYLE } from '../constants/select';
 
 import HairTypeInput from './HairTypeInput';
 import StyleButton from './StyleButton';
@@ -66,27 +66,19 @@ const DefaultInfo = () => {
               </h2>
               <span>{INFO_MESSAGE.PREFERENCE_SUBTITLE}</span>
             </S.Title>
-            <S.StyleBox>
-              <h3>{SELECT_TYPE.CUT}</h3>
-              <StyleButton isSelected={activateCheckbox('일반 커트')} type="일반 커트" />
-            </S.StyleBox>
-            <hr />
-            <S.StyleBox>
-              <h3>{SELECT_TYPE.COLOR}</h3>
-              <S.SelectList>
-                <StyleButton isSelected={activateCheckbox('전체 염색')} type="전체 염색" />
-                <StyleButton isSelected={activateCheckbox('전체 탈색')} type="전체 탈색" />
-              </S.SelectList>
-            </S.StyleBox>
-            <hr />
-            <S.StyleBox>
-              <h3>{SELECT_TYPE.PERM}</h3>
-              <S.SelectList>
-                <StyleButton isSelected={activateCheckbox('셋팅펌')} type="셋팅펌" />
-                <StyleButton isSelected={activateCheckbox('일반펌')} type="일반펌" />
-                <StyleButton isSelected={activateCheckbox('매직')} type="매직" />
-              </S.SelectList>
-            </S.StyleBox>
+            {SELECT_STYLE.map((element, index) => (
+              <>
+                <S.StyleBox key={element.TITLE}>
+                  <h3>{element.TITLE}</h3>
+                  <S.SelectList>
+                    {Object.keys(element.CONTENT).map((content) => (
+                      <StyleButton key={content} isSelected={activateCheckbox(content)} type={content} />
+                    ))}
+                  </S.SelectList>
+                </S.StyleBox>
+                {index === SELECT_STYLE.length - 1 ? null : <hr />}
+              </>
+            ))}
           </S.DeserveStyleSection>
         </S.StyleSection>
       </S.MainStyle>

--- a/src/views/ApplicationPage/components/HairTypeInput.tsx
+++ b/src/views/ApplicationPage/components/HairTypeInput.tsx
@@ -10,33 +10,32 @@ import longDefault from '../../@common/assets/images/btn_hair3_default.png';
 import longSelected from '../../@common/assets/images/btn_hair3_selected.png';
 import rapunzelDefault from '../../@common/assets/images/btn_hair4_default.png';
 import rapunzelSelected from '../../@common/assets/images/btn_hair4_selected.png';
+import { SELECT_LENGTH } from '../constants/select';
 
 import { hairStyleState } from '@/recoil/atoms/applicationState';
 
 interface HairTypeInputProps {
-  imgIdx: number;
   type: string;
 }
 
-const HairTypeInput = ({ imgIdx, type }: HairTypeInputProps) => {
+const HairTypeInput = ({ type }: HairTypeInputProps) => {
   const [selectedStyle, setSelectedStyle] = useRecoilState(hairStyleState);
-  const { length, lengthStatus } = selectedStyle;
   const [hairImg, setHairImg] = useState<string[]>(['', '']);
+  const [isActive, setIsActive] = useState(false);
 
   useEffect(() => {
     let images;
-
-    switch (imgIdx) {
-      case 0:
+    switch (type) {
+      case SELECT_LENGTH[0]:
         images = [shortDefault, shortSelected];
         break;
-      case 1:
+      case SELECT_LENGTH[1]:
         images = [mediumDefault, mediumSelected];
         break;
-      case 2:
+      case SELECT_LENGTH[2]:
         images = [longDefault, longSelected];
         break;
-      case 3:
+      case SELECT_LENGTH[3]:
         images = [rapunzelDefault, rapunzelSelected];
         break;
       default:
@@ -44,26 +43,21 @@ const HairTypeInput = ({ imgIdx, type }: HairTypeInputProps) => {
     }
     setHairImg(images);
 
-    const tempLengthState = [...lengthStatus];
-
-    type === length ? (tempLengthState[imgIdx] = true) : (tempLengthState[imgIdx] = false);
-    setSelectedStyle({ ...selectedStyle, lengthStatus: tempLengthState });
-  }, []);
-
-  const onlySelected = () => {
-    const tempLengthState = [...lengthStatus];
-    tempLengthState.forEach((_, index) =>
-      index === imgIdx ? (tempLengthState[index] = true) : (tempLengthState[index] = false),
-    );
-
-    setSelectedStyle({ ...selectedStyle, lengthStatus: tempLengthState, length: type });
-  };
+    type === selectedStyle.length ? setIsActive(true) : setIsActive(false);
+  }, [selectedStyle.length]);
 
   return (
     <>
-      <S.HairTypeInput type="radio" id={type} name="hairtype" onChange={onlySelected} />
+      <S.HairTypeInput
+        type="radio"
+        id={type}
+        name="hairtype"
+        onChange={() => {
+          setSelectedStyle({ ...selectedStyle, length: type });
+        }}
+      />
       <S.HairType htmlFor={type}>
-        <img src={lengthStatus[imgIdx] ? hairImg[1] : hairImg[0]} alt="hairImg" />
+        <img src={isActive ? hairImg[1] : hairImg[0]} alt="hairImg" />
       </S.HairType>
     </>
   );

--- a/src/views/ApplicationPage/components/HairTypeInput.tsx
+++ b/src/views/ApplicationPage/components/HairTypeInput.tsx
@@ -2,14 +2,6 @@ import { useEffect, useState } from 'react';
 import { useRecoilState } from 'recoil';
 import { styled } from 'styled-components';
 
-import shortDefault from '../../@common/assets/images/btn_hair1_default.png';
-import shortSelected from '../../@common/assets/images/btn_hair1_selected.png';
-import mediumDefault from '../../@common/assets/images/btn_hair2_default.png';
-import mediumSelected from '../../@common/assets/images/btn_hair2_selected.png';
-import longDefault from '../../@common/assets/images/btn_hair3_default.png';
-import longSelected from '../../@common/assets/images/btn_hair3_selected.png';
-import rapunzelDefault from '../../@common/assets/images/btn_hair4_default.png';
-import rapunzelSelected from '../../@common/assets/images/btn_hair4_selected.png';
 import { SELECT_LENGTH } from '../constants/select';
 
 import { hairStyleState } from '@/recoil/atoms/applicationState';
@@ -24,24 +16,9 @@ const HairTypeInput = ({ type }: HairTypeInputProps) => {
   const [isActive, setIsActive] = useState(false);
 
   useEffect(() => {
-    let images;
-    switch (type) {
-      case SELECT_LENGTH[0]:
-        images = [shortDefault, shortSelected];
-        break;
-      case SELECT_LENGTH[1]:
-        images = [mediumDefault, mediumSelected];
-        break;
-      case SELECT_LENGTH[2]:
-        images = [longDefault, longSelected];
-        break;
-      case SELECT_LENGTH[3]:
-        images = [rapunzelDefault, rapunzelSelected];
-        break;
-      default:
-        images = ['', ''];
-    }
-    setHairImg(images);
+    SELECT_LENGTH.forEach((item) => {
+      if (item.LENGTH === type) setHairImg([item.IMAGES.DEFAULT, item.IMAGES.SELECTED]);
+    });
 
     type === selectedStyle.length ? setIsActive(true) : setIsActive(false);
   }, [selectedStyle.length]);
@@ -57,7 +34,7 @@ const HairTypeInput = ({ type }: HairTypeInputProps) => {
         }}
       />
       <S.HairType htmlFor={type}>
-        <img src={isActive ? hairImg[1] : hairImg[0]} alt="hairImg" />
+        <img src={!isActive ? hairImg[0] : hairImg[1]} alt="hairImg" />
       </S.HairType>
     </>
   );

--- a/src/views/ApplicationPage/components/HairTypeInput.tsx
+++ b/src/views/ApplicationPage/components/HairTypeInput.tsx
@@ -25,6 +25,7 @@ const HairTypeInput = ({ imgIdx, type }: HairTypeInputProps) => {
 
   useEffect(() => {
     let images;
+
     switch (imgIdx) {
       case 0:
         images = [shortDefault, shortSelected];

--- a/src/views/ApplicationPage/constants/select.ts
+++ b/src/views/ApplicationPage/constants/select.ts
@@ -1,4 +1,18 @@
-export const SELECT_LENGTH = ['SHORT', 'ABOVE_SHOULDER', 'UNDER_SHOULDER', 'UNDER_WAIST'];
+import shortDefault from '../../@common/assets/images/btn_hair1_default.png';
+import shortSelected from '../../@common/assets/images/btn_hair1_selected.png';
+import mediumDefault from '../../@common/assets/images/btn_hair2_default.png';
+import mediumSelected from '../../@common/assets/images/btn_hair2_selected.png';
+import longDefault from '../../@common/assets/images/btn_hair3_default.png';
+import longSelected from '../../@common/assets/images/btn_hair3_selected.png';
+import rapunzelDefault from '../../@common/assets/images/btn_hair4_default.png';
+import rapunzelSelected from '../../@common/assets/images/btn_hair4_selected.png';
+
+export const SELECT_LENGTH = [
+  { LENGTH: 'SHORT', IMAGES: { DEFAULT: shortDefault, SELECTED: shortSelected } },
+  { LENGTH: 'ABOVE_SHOULDER', IMAGES: { DEFAULT: mediumDefault, SELECTED: mediumSelected } },
+  { LENGTH: 'UNDER_SHOULDER', IMAGES: { DEFAULT: longDefault, SELECTED: longSelected } },
+  { LENGTH: 'UNDER_WAIST', IMAGES: { DEFAULT: rapunzelDefault, SELECTED: rapunzelSelected } },
+];
 
 export const SELECT_TYPE = {
   CUT: '커트',

--- a/src/views/ApplicationPage/constants/select.ts
+++ b/src/views/ApplicationPage/constants/select.ts
@@ -1,3 +1,5 @@
+export const SELECT_LENGTH = ['SHORT', 'ABOVE_SHOULDER', 'UNDER_SHOULDER', 'UNDER_WAIST'];
+
 export const SELECT_TYPE = {
   CUT: '커트',
   COLOR: '컬러',

--- a/src/views/ApplicationPage/constants/select.ts
+++ b/src/views/ApplicationPage/constants/select.ts
@@ -6,6 +6,25 @@ export const SELECT_TYPE = {
   PERM: '펌',
 };
 
+export const SELECT_STYLE = [
+  { TITLE: '커트', CONTENT: { '일반 커트': 'NORMAL_CUT' } },
+  {
+    TITLE: '컬러',
+    CONTENT: {
+      '전체 염색': 'ALL_COLOR',
+      '전체 탈색': 'ALL_DECOLOR',
+    },
+  },
+  {
+    TITLE: '펌',
+    CONTENT: {
+      셋팅펌: 'SETTING_PERM ',
+      일반펌: 'NORMAL_PERM',
+      매직: 'STRAIGHTENING ',
+    },
+  },
+];
+
 export const SELECT_SERVICE = {
   펌: 'PERM',
   탈색: 'DECOLOR',
@@ -19,13 +38,4 @@ export const SELECT_PERIOD = {
   '4 - 6개월': 'FOUR_SIX',
   '7 - 12개월': 'SEVEN_TWELVE',
   '12 개월 초과': 'ABOVE_TWELVE',
-};
-
-export const SELECT_STYLE = {
-  '일반 커트': 'NORMAL_CUT',
-  '전체 염색': 'ALL_COLOR',
-  '전체 탈색': 'ALL_DECOLOR',
-  셋팅펌: 'SETTING_PERM ',
-  일반펌: 'NORMAL_PERM',
-  매직: 'STRAIGHTENING ',
 };


### PR DESCRIPTION
<!-- PR의 제목은 "[페이지명] 구현내용 " 으로, 연결되는 이슈 제목과 동일하게 가져가시면 됩니다! -->

![PR](https://github.com/TEAM-MODDY/moddy-web/assets/81505421/2d53d2e3-fcc8-4b65-835a-b118664382be)

## ▶️ Related Issue

- close #368 

<br />

## ✅ Done Task
- [x] 상수화
- [x] 상태관리 리팩토링 

<br />

## 🔎 PR Point

<!-- 리뷰어에게 나의 코드를 설명해주세요 -->
### **🚨** 리팩토링 목표

`DefaultInfo`라는 컴포넌트 안에서 전역 상태든 컴포넌트 단의 상태이든 상태 관리가 잘 되고 있지 않는 거 같아서 이 부분을 리팩토링해보았습니다

<img width="640" alt="before" src="https://github.com/TEAM-MODDY/moddy-web/assets/101045330/5369a9bd-71a6-423b-bdf6-1782dd4bac73">

상태들을 알아보기 힘들 수도 있을 거 같아서 간단하게 정리해보았습니다 !

여기서 취소선으로 그어진 것들이 리팩토링 하면서 사라진 `state`와 `props`이고 굵게 표시된 `isActive`가 새롭게 추가 된 상태입니다.

리팩토링의 목표는

1. **굳이 전역상태로 관리할 필요가 없는 `lengthStatus`라는 전역상태를 없애고**
2. **함수 혹은 이미 있는 변수들을 활용해서**
3. **단순히 보여지는 걸로만 의미 있는 것이 아니라 코드적으로도 의미가 통하게**

만들고 싶었습니다.

그래서 `HairTypeInput` 위주로 리팩토링과 `select.ts`에서 상수화 작업을 진행했습니다. 이 두 파일들 위주로 봐주시면 될 것 같아요 !

### **🚨** 변경 계획

리팩토링을 계획하면서 가장 큰 문제라고 느껴졌던 부분은

1️⃣ 머리 기장 버튼을 눌러서 선택값을 변경할 때마다 **활성화 여부**와 **기장 값**을 연관이 없는 별도의 `state`들로 관리하고 있다는 점

2️⃣ **imgIdx**라는 재사용성도 떨어지고 고유성?도 떨어지는 `props`를 사용해서 `HairTypeInput`에 출력될 이미지와 활성화 여부를 관리하고 있다는 점

그래서

1️⃣ 선택된 **기장 값**을 사용해서 버튼을 활성화 시키기

2️⃣ **기장 값**을 사용해서 이미지와 활성화 여부를 관리하기

**결론적으로, `length`라는 하나의 전역 상태에 의해 컴포넌트들이 렌더링되기를 바랐습니다 !**

결국 위의 컴포넌트들이 렌더링되는 과정은 사용자로부터 `length` 값을 얻기 위한 과정이기 때문이지요

### **🚨** 상수화

일단 코드를 단순화하기 위해서

```tsx
export const SELECT_LENGTH = [
  { LENGTH: 'SHORT', IMAGES: { DEFAULT: shortDefault, SELECTED: shortSelected } },
  { LENGTH: 'ABOVE_SHOULDER', IMAGES: { DEFAULT: mediumDefault, SELECTED: mediumSelected } },
  { LENGTH: 'UNDER_SHOULDER', IMAGES: { DEFAULT: longDefault, SELECTED: longSelected } },
  { LENGTH: 'UNDER_WAIST', IMAGES: { DEFAULT: rapunzelDefault, SELECTED: rapunzelSelected } },
];

export const SELECT_STYLE = [
  { TITLE: '커트', CONTENT: { '일반 커트': 'NORMAL_CUT' } },
  {
    TITLE: '컬러',
    CONTENT: {
      '전체 염색': 'ALL_COLOR',
      '전체 탈색': 'ALL_DECOLOR',
    },
  },
  {
    TITLE: '펌',
    CONTENT: {
      셋팅펌: 'SETTING_PERM ',
      일반펌: 'NORMAL_PERM',
      매직: 'STRAIGHTENING ',
    },
  },
];
```

다음과 같이 상수화 작업을 진행했고

덕분에 아래와 같이 코드를 단순화할 수 있었습니다 

**⚡ 변경 전**

```tsx
	<S.HairTypeInputBox>
	  <HairTypeInput imgIdx={0} type="SHORT" />
	  <HairTypeInput imgIdx={1} type="ABOVE_SHOULDER" />
	  <HairTypeInput imgIdx={2} type="UNDER_SHOULDER" />
	  <HairTypeInput imgIdx={3} type="UNDER_WAIST" />
	</S.HairTypeInputBox>
//...
	<S.StyleBox>
	  <h3>{SELECT_TYPE.CUT}</h3>
	  <StyleButton isSelected={activateCheckbox('일반 커트')} type="일반 커트" />
	</S.StyleBox>
	<hr />
	<S.StyleBox>
	  <h3>{SELECT_TYPE.COLOR}</h3>
	  <S.SelectList>
	    <StyleButton isSelected={activateCheckbox('전체 염색')} type="전체 염색" />
	    <StyleButton isSelected={activateCheckbox('전체 탈색')} type="전체 탈색" />
	  </S.SelectList>
	</S.StyleBox>
	<hr />
	<S.StyleBox>
	  <h3>{SELECT_TYPE.PERM}</h3>
	  <S.SelectList>
	    <StyleButton isSelected={activateCheckbox('셋팅펌')} type="셋팅펌" />
	    <StyleButton isSelected={activateCheckbox('일반펌')} type="일반펌" />
	    <StyleButton isSelected={activateCheckbox('매직')} type="매직" />
	  </S.SelectList>
	</S.StyleBox>
//...
	let images;
	    switch (imgIdx) {
	      case 0:
	        images = [shortDefault, shortSelected];
	        break;
	      case 1:
	        images = [mediumDefault, mediumSelected];
	        break;
	      case 2:
	        images = [longDefault, longSelected];
	        break;
	      case 3:
	        images = [rapunzelDefault, rapunzelSelected];
	        break;
	      default:
	        images = ['', ''];
	    }
	  setHairImg(images);
```

**⚡ 변경 후**

```tsx
  <S.HairTypeInputBox>
    {SELECT_LENGTH.map((element) => (
      <HairTypeInput key={element.LENGTH} type={element.LENGTH} />
    ))}
	</S.HairTypeInputBox>
	//...
	{SELECT_STYLE.map((element, index) => (
	  <React.Fragment key={element.TITLE}>
	    <S.StyleBox>
	      <h3>{element.TITLE}</h3>
	      <S.SelectList>
	        {Object.keys(element.CONTENT).map((content) => (
	          <StyleButton key={content} isSelected={activateCheckbox(content)} type={content} />
	        ))}
	      </S.SelectList>
	    </S.StyleBox>
	    {index === SELECT_STYLE.length - 1 ? null : <hr />}
	  </React.Fragment>
	))}
//...
	SELECT_LENGTH.forEach((item) => {
      if (item.LENGTH === type) setHairImg([item.IMAGES.DEFAULT, item.IMAGES.SELECTED]);
  });
```

이때, `imgIdx` props를 없애주었습니다

### **🚨** 전역 상태 → 일반 상태

`imgIdx` props와 `lengthStatus`라는 전역 상태 두 가지를 제거해주면서 `HairTypeInput` 버튼을 클릭했을 때, 선택된 기장값(전역상태 `length`)에 따라 컴포넌트에서 필요한 모든 값들이 렌더링되기를 바랐습니다.

```tsx
const onlySelected = () => {
    ~~const tempLengthState = [...lengthStatus];
    tempLengthState.forEach((_, index) =>
      index === imgIdx ? (tempLengthState[index] = true) : (tempLengthState[index] = false),
    );~~

    setSelectedStyle({ ...selectedStyle, ~~lengthStatus: tempLengthState,~~ length: type });
  };
```

`onlySelected`라는 함수를 없애고 `setter` 함수만 남겨놓았습니다.

<br />

## 🧨 Trouble Shooting

<!-- 없으면 삭제 -->
`map`함수와 `key` props에 대한 작은 트러블 슈팅을 겪었습니다
```tsx
{SELECT_STYLE.map((element, index) => (
    <React.Fragment key={element.TITLE}>
       <S.StyleBox>
        <h3>{element.TITLE}</h3>
         <S.SelectList>
          {Object.keys(element.CONTENT).map((content) => (
            <StyleButton key={content} isSelected={activateCheckbox(content)} type={content} />
          ))}
         </S.SelectList>
        </S.StyleBox>
       {index === SELECT_STYLE.length - 1 ? null : <hr />}
     </React.Fragment>
```

`React.Fragment`를 최상위 태그로 해서 `map`을 돌릴 때는 꼭 위와 같이 빈 태그 말고 직접 명시해서 `key` props 부여해주어야 합니다 ! !
> `key`는 컴포넌트 배열을 렌더링했을 때 어떤 요소에 변동이 있었는지 알아내려고 사용하는데 유동적인 데이터를 다룰 때는 `key`가 없다면 Virtual DOM을 비교하는 과정에서 리스트를 순차적으로 모두 비교하면서 변화를 감지한다고 합니다. 하지만 `key`가 있다면 이 값을 이용하여 어떤 변화가 일어났는지 더욱 빠르게 알아낼 수 있습니다. (같은 `key` 값을 가진 애들끼리만 비교)


