### PR TITLE
[ApplicationPage] 시술 내역 드롭다운 박스 단일 활성화 기능 추가

### DIFF
--- a/src/views/ApplicationPage/components/ServiceHistory.tsx
+++ b/src/views/ApplicationPage/components/ServiceHistory.tsx
@@ -21,16 +21,16 @@ const ServiceHistory = () => {
   const historyRef = useRef<HTMLUListElement>(null);
   const navigate = useNavigate();
 
-  // useEffect(() => {
-  //   const handleFocus = (e: MouseEvent) => {
-  //     if (historyRef.current && !historyRef.current.contains(e.target as Node)) setCurrentDropDown(null);
-  //   };
-  //   document.addEventListener('mouseup', handleFocus);
+  useEffect(() => {
+    const handleFocus = (e: MouseEvent) => {
+      if (historyRef.current && !historyRef.current.contains(e.target as Node)) setCurrentDropDown(null);
+    };
+    document.addEventListener('mouseup', handleFocus);
 
-  //   return () => {
-  //     document.removeEventListener('mouseup', handleFocus);
-  //   };
-  // }, [historyRef.current]);
+    return () => {
+      document.removeEventListener('mouseup', handleFocus);
+    };
+  }, [historyRef.current]);
 
   const addHistory = () => {
     if (serviceHistory.hairServiceRecords.length < MAX_LENGTH) {

--- a/src/views/ApplicationPage/components/ServiceHistory.tsx
+++ b/src/views/ApplicationPage/components/ServiceHistory.tsx
@@ -1,4 +1,4 @@
-import { useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useRecoilState } from 'recoil';
 import { styled } from 'styled-components';
@@ -17,8 +17,20 @@ const ServiceHistory = () => {
 
   const [step, setStep] = useRecoilState(applyStepState);
   const [serviceHistory, setServiceHistory] = useRecoilState(historyState);
-  const activateRef = useRef<HTMLDivElement>(null);
+  const [currentDropDown, setCurrentDropDown] = useState<number | null>(null);
+  const historyRef = useRef<HTMLUListElement>(null);
   const navigate = useNavigate();
+
+  // useEffect(() => {
+  //   const handleFocus = (e: MouseEvent) => {
+  //     if (historyRef.current && !historyRef.current.contains(e.target as Node)) setCurrentDropDown(null);
+  //   };
+  //   document.addEventListener('mouseup', handleFocus);
+
+  //   return () => {
+  //     document.removeEventListener('mouseup', handleFocus);
+  //   };
+  // }, [historyRef.current]);
 
   const addHistory = () => {
     if (serviceHistory.hairServiceRecords.length < MAX_LENGTH) {
@@ -56,11 +68,12 @@ const ServiceHistory = () => {
         <h2>{INFO_MESSAGE.SERVICE_TITLE}</h2>
         <h3>{INFO_MESSAGE.SERVICE_SUBTITLE}</h3>
       </S.Title>
-      <S.ServiceHistoryList>
+      <S.ServiceHistoryList ref={historyRef}>
         {serviceHistory.hairServiceRecords.map((item, idx) => (
           <ServiceHistoryListItem
             key={'history' + item.hairService + item.hairServiceTerm + idx}
-            ref={activateRef}
+            currentDropDown={currentDropDown}
+            setCurrentDropDown={setCurrentDropDown}
             idx={idx}
           />
         ))}

--- a/src/views/ApplicationPage/components/ServiceHistory.tsx
+++ b/src/views/ApplicationPage/components/ServiceHistory.tsx
@@ -16,13 +16,12 @@ const ServiceHistory = () => {
 
   const [step, setStep] = useRecoilState(applyStepState);
   const [serviceHistory, setServiceHistory] = useRecoilState(historyState);
-  const { hairServiceRecords } = serviceHistory;
   const navigate = useNavigate();
 
   const addHistory = () => {
-    if (hairServiceRecords.length < MAX_LENGTH) {
+    if (serviceHistory.hairServiceRecords.length < MAX_LENGTH) {
       const tempServiceHistoryList: historyDetailProps[] = [
-        ...hairServiceRecords,
+        ...serviceHistory.hairServiceRecords,
         { hairService: '', hairServiceTerm: '' },
       ];
       setServiceHistory({ ...serviceHistory, hairServiceRecords: tempServiceHistoryList });
@@ -56,11 +55,9 @@ const ServiceHistory = () => {
         <h3>{INFO_MESSAGE.SERVICE_SUBTITLE}</h3>
       </S.Title>
       <S.ServiceHistoryList>
-        {hairServiceRecords.map((item, idx: number) =>
-          idx < hairServiceRecords.length ? (
-            <ServiceHistoryListItem key={'history' + item.hairService + item.hairServiceTerm + idx} idx={idx} />
-          ) : null,
-        )}
+        {serviceHistory.hairServiceRecords.map((item, idx) => (
+          <ServiceHistoryListItem key={'history' + item.hairService + item.hairServiceTerm + idx} idx={idx} />
+        ))}
       </S.ServiceHistoryList>
       <S.AddHistoryBtn type="button" onClick={addHistory}>
         {INFO_MESSAGE.ADD_HISTORY}

--- a/src/views/ApplicationPage/components/ServiceHistory.tsx
+++ b/src/views/ApplicationPage/components/ServiceHistory.tsx
@@ -1,3 +1,4 @@
+import { useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useRecoilState } from 'recoil';
 import { styled } from 'styled-components';
@@ -16,6 +17,7 @@ const ServiceHistory = () => {
 
   const [step, setStep] = useRecoilState(applyStepState);
   const [serviceHistory, setServiceHistory] = useRecoilState(historyState);
+  const activateRef = useRef<HTMLDivElement>(null);
   const navigate = useNavigate();
 
   const addHistory = () => {
@@ -56,7 +58,11 @@ const ServiceHistory = () => {
       </S.Title>
       <S.ServiceHistoryList>
         {serviceHistory.hairServiceRecords.map((item, idx) => (
-          <ServiceHistoryListItem key={'history' + item.hairService + item.hairServiceTerm + idx} idx={idx} />
+          <ServiceHistoryListItem
+            key={'history' + item.hairService + item.hairServiceTerm + idx}
+            ref={activateRef}
+            idx={idx}
+          />
         ))}
       </S.ServiceHistoryList>
       <S.AddHistoryBtn type="button" onClick={addHistory}>

--- a/src/views/ApplicationPage/components/ServiceHistory.tsx
+++ b/src/views/ApplicationPage/components/ServiceHistory.tsx
@@ -9,7 +9,7 @@ import { INFO_MESSAGE } from '../constants/message';
 
 import ServiceHistoryListItem from './ServiceHistoryListItem';
 
-import { applyStepState, historyDetailProps, historyState } from '@/recoil/atoms/applicationState';
+import { applyStepState, historyState } from '@/recoil/atoms/applicationState';
 import ProgressBar from '@/views/@common/components/ProgressBar';
 
 const ServiceHistory = () => {
@@ -33,13 +33,13 @@ const ServiceHistory = () => {
   }, [historyRef.current]);
 
   const addHistory = () => {
-    if (serviceHistory.hairServiceRecords.length < MAX_LENGTH) {
-      const tempServiceHistoryList: historyDetailProps[] = [
-        ...serviceHistory.hairServiceRecords,
-        { hairService: '', hairServiceTerm: '' },
-      ];
-      setServiceHistory({ ...serviceHistory, hairServiceRecords: tempServiceHistoryList });
-    }
+    setServiceHistory((prev) => ({
+      ...prev,
+      hairServiceRecords:
+        prev.hairServiceRecords.length < MAX_LENGTH
+          ? [...prev.hairServiceRecords, { hairService: '', hairServiceTerm: '' }]
+          : prev.hairServiceRecords,
+    }));
   };
 
   const exceptionNull = () => {

--- a/src/views/ApplicationPage/components/ServiceHistoryListItem.tsx
+++ b/src/views/ApplicationPage/components/ServiceHistoryListItem.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, useState } from 'react';
+import React, { useState } from 'react';
 import { useRecoilState } from 'recoil';
 import { css, styled } from 'styled-components';
 
@@ -14,93 +14,90 @@ interface ServiceHistoryListItem {
   setCurrentDropDown: React.Dispatch<React.SetStateAction<number | null>>;
 }
 
-const ServiceHistoryListItem = forwardRef<HTMLDivElement, ServiceHistoryListItem>(
-  ({ idx, currentDropDown, setCurrentDropDown }) => {
-    const [serviceHistory, setServiceHistory] = useRecoilState(historyState);
-    const [clickedDropdown, setClickedDropdown] = useState<string | null>(null);
+const ServiceHistoryListItem = ({ idx, currentDropDown, setCurrentDropDown }: ServiceHistoryListItem) => {
+  const [serviceHistory, setServiceHistory] = useRecoilState(historyState);
+  const [clickedDropdown, setClickedDropdown] = useState<string | null>(null);
 
-    const handleDropdownClick = (
-      event: React.MouseEvent<HTMLButtonElement, MouseEvent>,
-      field: 'hairService' | 'hairServiceTerm',
-    ) => {
-      const newValue = event.currentTarget.innerText;
-      const newServiceHistoryRecords = serviceHistory.hairServiceRecords.map((item, i) => {
-        if (i === idx) {
-          return {
-            ...item,
-            [field]: newValue,
-          };
-        }
-        return item;
-      });
+  const handleDropdownClick = (
+    event: React.MouseEvent<HTMLButtonElement, MouseEvent>,
+    field: 'hairService' | 'hairServiceTerm',
+  ) => {
+    const newValue = event.currentTarget.innerText;
+    const newServiceHistoryRecords = serviceHistory.hairServiceRecords.map((item, i) => {
+      if (i === idx) {
+        return {
+          ...item,
+          [field]: newValue,
+        };
+      }
+      return item;
+    });
 
-      setServiceHistory({ ...serviceHistory, hairServiceRecords: newServiceHistoryRecords });
-      setClickedDropdown(null);
-    };
+    setServiceHistory({ ...serviceHistory, hairServiceRecords: newServiceHistoryRecords });
+    setClickedDropdown(null);
+  };
 
-    const deleteHistory = () => {
-      const newServiceHistoryRecords = serviceHistory.hairServiceRecords.filter((_, i) => i !== idx);
-      setServiceHistory({ ...serviceHistory, hairServiceRecords: newServiceHistoryRecords });
-    };
+  const deleteHistory = () => {
+    const newServiceHistoryRecords = serviceHistory.hairServiceRecords.filter((_, i) => i !== idx);
+    setServiceHistory({ ...serviceHistory, hairServiceRecords: newServiceHistoryRecords });
+  };
 
-    return (
-      <S.ServiceHistoryListItemLayout>
-        <S.SelectBox $height={idx}>
-          <S.DropDownBox
-            $isClicked={currentDropDown === idx && clickedDropdown === 'service'}
-            onClick={() => {
-              setCurrentDropDown(idx);
-              currentDropDown === idx && clickedDropdown === 'service'
-                ? setClickedDropdown(null)
-                : setClickedDropdown('service');
-            }}>
-            <input type="button" value={serviceHistory.hairServiceRecords[idx].hairService || '시술  선택'} />
-            {currentDropDown === idx && clickedDropdown === 'service' ? <IcUpBlue /> : <IcDownGrey />}
-            {currentDropDown === idx && clickedDropdown === 'service' && (
-              <S.SelectDetailList>
-                {Object.keys(SELECT_SERVICE).map((value, key) => (
-                  <li key={key}>
-                    <button type="button" onClick={(e) => handleDropdownClick(e, 'hairService')}>
-                      {value}
-                    </button>
-                  </li>
-                ))}
-              </S.SelectDetailList>
-            )}
-          </S.DropDownBox>
-        </S.SelectBox>
-        <S.SelectBox $height={idx}>
-          <S.DropDownBox
-            $isClicked={currentDropDown === idx && clickedDropdown === 'period'}
-            onClick={() => {
-              setCurrentDropDown(idx);
-              currentDropDown === idx && clickedDropdown === 'period'
-                ? setClickedDropdown(null)
-                : setClickedDropdown('period');
-            }}>
-            <input type="button" value={serviceHistory.hairServiceRecords[idx].hairServiceTerm || '기간  선택'} />
-            {currentDropDown === idx && clickedDropdown === 'period' ? <IcUpBlue /> : <IcDownGrey />}
-            {currentDropDown === idx && clickedDropdown === 'period' && (
-              <S.SelectDetailList>
-                {Object.keys(SELECT_PERIOD).map((value, key) => (
-                  <li key={key}>
-                    <button type="button" onClick={(e) => handleDropdownClick(e, 'hairServiceTerm')}>
-                      {value}
-                    </button>
-                  </li>
-                ))}
-              </S.SelectDetailList>
-            )}
-          </S.DropDownBox>
-        </S.SelectBox>
-        <button type="button" onClick={deleteHistory}>
-          <IcDelete />
-        </button>
-      </S.ServiceHistoryListItemLayout>
-    );
-  },
-);
-ServiceHistoryListItem.displayName = 'ServiceHistoryListItem';
+  return (
+    <S.ServiceHistoryListItemLayout>
+      <S.SelectBox $height={idx}>
+        <S.DropDownBox
+          $isClicked={currentDropDown === idx && clickedDropdown === 'service'}
+          onClick={() => {
+            setCurrentDropDown(idx);
+            currentDropDown === idx && clickedDropdown === 'service'
+              ? setClickedDropdown(null)
+              : setClickedDropdown('service');
+          }}>
+          <input type="button" value={serviceHistory.hairServiceRecords[idx].hairService || '시술  선택'} />
+          {currentDropDown === idx && clickedDropdown === 'service' ? <IcUpBlue /> : <IcDownGrey />}
+          {currentDropDown === idx && clickedDropdown === 'service' && (
+            <S.SelectDetailList>
+              {Object.keys(SELECT_SERVICE).map((value, key) => (
+                <li key={key}>
+                  <button type="button" onClick={(e) => handleDropdownClick(e, 'hairService')}>
+                    {value}
+                  </button>
+                </li>
+              ))}
+            </S.SelectDetailList>
+          )}
+        </S.DropDownBox>
+      </S.SelectBox>
+      <S.SelectBox $height={idx}>
+        <S.DropDownBox
+          $isClicked={currentDropDown === idx && clickedDropdown === 'period'}
+          onClick={() => {
+            setCurrentDropDown(idx);
+            currentDropDown === idx && clickedDropdown === 'period'
+              ? setClickedDropdown(null)
+              : setClickedDropdown('period');
+          }}>
+          <input type="button" value={serviceHistory.hairServiceRecords[idx].hairServiceTerm || '기간  선택'} />
+          {currentDropDown === idx && clickedDropdown === 'period' ? <IcUpBlue /> : <IcDownGrey />}
+          {currentDropDown === idx && clickedDropdown === 'period' && (
+            <S.SelectDetailList>
+              {Object.keys(SELECT_PERIOD).map((value, key) => (
+                <li key={key}>
+                  <button type="button" onClick={(e) => handleDropdownClick(e, 'hairServiceTerm')}>
+                    {value}
+                  </button>
+                </li>
+              ))}
+            </S.SelectDetailList>
+          )}
+        </S.DropDownBox>
+      </S.SelectBox>
+      <button type="button" onClick={deleteHistory}>
+        <IcDelete />
+      </button>
+    </S.ServiceHistoryListItemLayout>
+  );
+};
 
 const ServiceHistoryListItemLayout = styled.li`
   display: flex;

--- a/src/views/ApplicationPage/components/ServiceHistoryListItem.tsx
+++ b/src/views/ApplicationPage/components/ServiceHistoryListItem.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, useState } from 'react';
+import React, { forwardRef, useState } from 'react';
 import { useRecoilState } from 'recoil';
 import { css, styled } from 'styled-components';
 
@@ -7,113 +7,78 @@ import { IcDelete } from '../assets/icons';
 import { SELECT_PERIOD, SELECT_SERVICE } from '../constants/select';
 
 import { historyState } from '@/recoil/atoms/applicationState';
+
 interface ServiceHistoryListItem {
   idx: number;
 }
 
 const ServiceHistoryListItem = forwardRef<HTMLDivElement, ServiceHistoryListItem>(({ idx }, ref) => {
   const [serviceHistory, setServiceHistory] = useRecoilState(historyState);
-  const { hairServiceRecords } = serviceHistory;
-  const [isServiceClicked, setIsServiceClicked] = useState(false);
-  const [isPeriodClicked, setIsPeriodClicked] = useState(false);
+  const [clickedDropdown, setClickedDropdown] = useState<string | null>(null);
 
-  const activateServiceBox = (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
-    setIsServiceClicked((prev) => !prev);
-    const tempService = event.currentTarget.innerText;
-    const tempServiceHistoryList = hairServiceRecords.map((item, i) => {
+  const handleDropdownClick = (
+    event: React.MouseEvent<HTMLButtonElement, MouseEvent>,
+    field: 'hairService' | 'hairServiceTerm',
+  ) => {
+    const newValue = event.currentTarget.innerText;
+    const newServiceHistoryRecords = serviceHistory.hairServiceRecords.map((item, i) => {
       if (i === idx) {
         return {
           ...item,
-          hairService: tempService,
+          [field]: newValue,
         };
       }
       return item;
     });
 
-    setServiceHistory({ ...serviceHistory, hairServiceRecords: tempServiceHistoryList });
-  };
-
-  const activatePeriodBox = (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
-    setIsPeriodClicked((prev) => !prev);
-    const tempPeriod = event.currentTarget.innerText;
-    const tempServiceHistoryList = hairServiceRecords.map((item, i) => {
-      if (i === idx) {
-        return {
-          ...item,
-          hairServiceTerm: tempPeriod,
-        };
-      }
-      return item;
-    });
-
-    setServiceHistory({ ...serviceHistory, hairServiceRecords: tempServiceHistoryList });
+    setServiceHistory({ ...serviceHistory, hairServiceRecords: newServiceHistoryRecords });
+    setClickedDropdown(null);
   };
 
   const deleteHistory = () => {
-    const tempServiceHistoryList = hairServiceRecords.filter((_, i) => i !== idx);
-    if (tempServiceHistoryList.length >= 0) {
-      setServiceHistory({ ...serviceHistory, hairServiceRecords: tempServiceHistoryList });
-    }
+    const newServiceHistoryRecords = serviceHistory.hairServiceRecords.filter((_, i) => i !== idx);
+    setServiceHistory({ ...serviceHistory, hairServiceRecords: newServiceHistoryRecords });
   };
 
   return (
     <S.ServiceHistoryListItemLayout>
       <S.SelectBox $height={idx}>
-        <S.SelectServiceBox
-          ref={ref}
-          $isServiceClicked={isServiceClicked}
-          onClick={() => {
-            setIsServiceClicked((prev) => !prev);
-            console.log(ref);
-          }}>
-          <input
-            type="button"
-            value={hairServiceRecords[idx].hairService !== '' ? hairServiceRecords[idx].hairService : '시술 선택'}
-          />
-          {isServiceClicked ? <IcUpBlue /> : <IcDownGrey />}
-        </S.SelectServiceBox>
-        <div>
-          {isServiceClicked && (
+        <S.DropDownBox
+          $isClicked={clickedDropdown === 'service'}
+          onClick={() => (clickedDropdown ? setClickedDropdown(null) : setClickedDropdown('service'))}>
+          <input type="button" value={serviceHistory.hairServiceRecords[idx].hairService || '시술  선택'} />
+          {clickedDropdown === 'service' ? <IcUpBlue /> : <IcDownGrey />}
+          {clickedDropdown === 'service' && (
             <S.SelectDetailList>
               {Object.keys(SELECT_SERVICE).map((value, key) => (
                 <li key={key}>
-                  <button type="button" onClick={activateServiceBox}>
+                  <button type="button" onClick={(e) => handleDropdownClick(e, 'hairService')}>
                     {value}
                   </button>
                 </li>
               ))}
             </S.SelectDetailList>
           )}
-        </div>
+        </S.DropDownBox>
       </S.SelectBox>
       <S.SelectBox $height={idx}>
-        <S.SelectPeriodBox
-          ref={ref}
-          $isPeriodClicked={isPeriodClicked}
-          onClick={() => {
-            setIsPeriodClicked((prev) => !prev);
-          }}>
-          <input
-            type="button"
-            value={
-              hairServiceRecords[idx].hairServiceTerm !== '' ? hairServiceRecords[idx].hairServiceTerm : '기간 선택'
-            }
-          />
-          {isPeriodClicked ? <IcUpBlue /> : <IcDownGrey />}
-        </S.SelectPeriodBox>
-        <div>
-          {isPeriodClicked && (
+        <S.DropDownBox
+          $isClicked={clickedDropdown === 'period'}
+          onClick={() => (clickedDropdown ? setClickedDropdown(null) : setClickedDropdown('period'))}>
+          <input type="button" value={serviceHistory.hairServiceRecords[idx].hairServiceTerm || '기간  선택'} />
+          {clickedDropdown === 'period' ? <IcUpBlue /> : <IcDownGrey />}
+          {clickedDropdown === 'period' && (
             <S.SelectDetailList>
               {Object.keys(SELECT_PERIOD).map((value, key) => (
                 <li key={key}>
-                  <button type="button" onClick={activatePeriodBox}>
+                  <button type="button" onClick={(e) => handleDropdownClick(e, 'hairServiceTerm')}>
                     {value}
                   </button>
                 </li>
               ))}
             </S.SelectDetailList>
           )}
-        </div>
+        </S.DropDownBox>
       </S.SelectBox>
       <button type="button" onClick={deleteHistory}>
         <IcDelete />
@@ -191,25 +156,17 @@ const selectBtn = css`
   }
 `;
 
-const SelectServiceBox = styled.div<{ $isServiceClicked: boolean }>`
-  border: 1px solid
-    ${({ $isServiceClicked, theme }) => ($isServiceClicked ? theme.colors.moddy_blue : theme.colors.moddy_gray50)};
+const DropDownBox = styled.div<{ $isClicked: boolean }>`
+  border: 1px solid ${({ $isClicked, theme }) => ($isClicked ? theme.colors.moddy_blue : theme.colors.moddy_gray50)};
 
   ${selectBtn};
 `;
 
-const SelectPeriodBox = styled.div<{ $isPeriodClicked: boolean }>`
-  border: 1px solid
-    ${({ $isPeriodClicked, theme }) => ($isPeriodClicked ? theme.colors.moddy_blue : theme.colors.moddy_gray50)};
-
-  ${selectBtn};
-`;
 const S = {
   ServiceHistoryListItemLayout,
   SelectBox,
   SelectDetailList,
-  SelectServiceBox,
-  SelectPeriodBox,
+  DropDownBox,
 };
 
 export default ServiceHistoryListItem;

--- a/src/views/ApplicationPage/components/ServiceHistoryListItem.tsx
+++ b/src/views/ApplicationPage/components/ServiceHistoryListItem.tsx
@@ -10,82 +10,96 @@ import { historyState } from '@/recoil/atoms/applicationState';
 
 interface ServiceHistoryListItem {
   idx: number;
+  currentDropDown: number | null;
+  setCurrentDropDown: React.Dispatch<React.SetStateAction<number | null>>;
 }
 
-const ServiceHistoryListItem = forwardRef<HTMLDivElement, ServiceHistoryListItem>(({ idx }, ref) => {
-  const [serviceHistory, setServiceHistory] = useRecoilState(historyState);
-  const [clickedDropdown, setClickedDropdown] = useState<string | null>(null);
+const ServiceHistoryListItem = forwardRef<HTMLDivElement, ServiceHistoryListItem>(
+  ({ idx, currentDropDown, setCurrentDropDown }) => {
+    const [serviceHistory, setServiceHistory] = useRecoilState(historyState);
+    const [clickedDropdown, setClickedDropdown] = useState<string | null>(null);
 
-  const handleDropdownClick = (
-    event: React.MouseEvent<HTMLButtonElement, MouseEvent>,
-    field: 'hairService' | 'hairServiceTerm',
-  ) => {
-    const newValue = event.currentTarget.innerText;
-    const newServiceHistoryRecords = serviceHistory.hairServiceRecords.map((item, i) => {
-      if (i === idx) {
-        return {
-          ...item,
-          [field]: newValue,
-        };
-      }
-      return item;
-    });
+    const handleDropdownClick = (
+      event: React.MouseEvent<HTMLButtonElement, MouseEvent>,
+      field: 'hairService' | 'hairServiceTerm',
+    ) => {
+      const newValue = event.currentTarget.innerText;
+      const newServiceHistoryRecords = serviceHistory.hairServiceRecords.map((item, i) => {
+        if (i === idx) {
+          return {
+            ...item,
+            [field]: newValue,
+          };
+        }
+        return item;
+      });
 
-    setServiceHistory({ ...serviceHistory, hairServiceRecords: newServiceHistoryRecords });
-    setClickedDropdown(null);
-  };
+      setServiceHistory({ ...serviceHistory, hairServiceRecords: newServiceHistoryRecords });
+      setClickedDropdown(null);
+    };
 
-  const deleteHistory = () => {
-    const newServiceHistoryRecords = serviceHistory.hairServiceRecords.filter((_, i) => i !== idx);
-    setServiceHistory({ ...serviceHistory, hairServiceRecords: newServiceHistoryRecords });
-  };
+    const deleteHistory = () => {
+      const newServiceHistoryRecords = serviceHistory.hairServiceRecords.filter((_, i) => i !== idx);
+      setServiceHistory({ ...serviceHistory, hairServiceRecords: newServiceHistoryRecords });
+    };
 
-  return (
-    <S.ServiceHistoryListItemLayout>
-      <S.SelectBox $height={idx}>
-        <S.DropDownBox
-          $isClicked={clickedDropdown === 'service'}
-          onClick={() => (clickedDropdown === 'service' ? setClickedDropdown(null) : setClickedDropdown('service'))}>
-          <input type="button" value={serviceHistory.hairServiceRecords[idx].hairService || '시술  선택'} />
-          {clickedDropdown === 'service' ? <IcUpBlue /> : <IcDownGrey />}
-          {clickedDropdown === 'service' && (
-            <S.SelectDetailList>
-              {Object.keys(SELECT_SERVICE).map((value, key) => (
-                <li key={key}>
-                  <button type="button" onClick={(e) => handleDropdownClick(e, 'hairService')}>
-                    {value}
-                  </button>
-                </li>
-              ))}
-            </S.SelectDetailList>
-          )}
-        </S.DropDownBox>
-      </S.SelectBox>
-      <S.SelectBox $height={idx}>
-        <S.DropDownBox
-          $isClicked={clickedDropdown === 'period'}
-          onClick={() => (clickedDropdown === 'period' ? setClickedDropdown(null) : setClickedDropdown('period'))}>
-          <input type="button" value={serviceHistory.hairServiceRecords[idx].hairServiceTerm || '기간  선택'} />
-          {clickedDropdown === 'period' ? <IcUpBlue /> : <IcDownGrey />}
-          {clickedDropdown === 'period' && (
-            <S.SelectDetailList>
-              {Object.keys(SELECT_PERIOD).map((value, key) => (
-                <li key={key}>
-                  <button type="button" onClick={(e) => handleDropdownClick(e, 'hairServiceTerm')}>
-                    {value}
-                  </button>
-                </li>
-              ))}
-            </S.SelectDetailList>
-          )}
-        </S.DropDownBox>
-      </S.SelectBox>
-      <button type="button" onClick={deleteHistory}>
-        <IcDelete />
-      </button>
-    </S.ServiceHistoryListItemLayout>
-  );
-});
+    return (
+      <S.ServiceHistoryListItemLayout>
+        <S.SelectBox $height={idx}>
+          <S.DropDownBox
+            $isClicked={currentDropDown === idx && clickedDropdown === 'service'}
+            onClick={() => {
+              setCurrentDropDown(idx);
+              currentDropDown === idx && clickedDropdown === 'service'
+                ? setClickedDropdown(null)
+                : setClickedDropdown('service');
+            }}>
+            <input type="button" value={serviceHistory.hairServiceRecords[idx].hairService || '시술  선택'} />
+            {currentDropDown === idx && clickedDropdown === 'service' ? <IcUpBlue /> : <IcDownGrey />}
+            {currentDropDown === idx && clickedDropdown === 'service' && (
+              <S.SelectDetailList>
+                {Object.keys(SELECT_SERVICE).map((value, key) => (
+                  <li key={key}>
+                    <button type="button" onClick={(e) => handleDropdownClick(e, 'hairService')}>
+                      {value}
+                    </button>
+                  </li>
+                ))}
+              </S.SelectDetailList>
+            )}
+          </S.DropDownBox>
+        </S.SelectBox>
+        <S.SelectBox $height={idx}>
+          <S.DropDownBox
+            $isClicked={currentDropDown === idx && clickedDropdown === 'period'}
+            onClick={() => {
+              setCurrentDropDown(idx);
+              currentDropDown === idx && clickedDropdown === 'period'
+                ? setClickedDropdown(null)
+                : setClickedDropdown('period');
+            }}>
+            <input type="button" value={serviceHistory.hairServiceRecords[idx].hairServiceTerm || '기간  선택'} />
+            {currentDropDown === idx && clickedDropdown === 'period' ? <IcUpBlue /> : <IcDownGrey />}
+            {currentDropDown === idx && clickedDropdown === 'period' && (
+              <S.SelectDetailList>
+                {Object.keys(SELECT_PERIOD).map((value, key) => (
+                  <li key={key}>
+                    <button type="button" onClick={(e) => handleDropdownClick(e, 'hairServiceTerm')}>
+                      {value}
+                    </button>
+                  </li>
+                ))}
+              </S.SelectDetailList>
+            )}
+          </S.DropDownBox>
+        </S.SelectBox>
+        <button type="button" onClick={deleteHistory}>
+          <IcDelete />
+        </button>
+      </S.ServiceHistoryListItemLayout>
+    );
+  },
+);
 ServiceHistoryListItem.displayName = 'ServiceHistoryListItem';
 
 const ServiceHistoryListItemLayout = styled.li`

--- a/src/views/ApplicationPage/components/ServiceHistoryListItem.tsx
+++ b/src/views/ApplicationPage/components/ServiceHistoryListItem.tsx
@@ -45,7 +45,7 @@ const ServiceHistoryListItem = forwardRef<HTMLDivElement, ServiceHistoryListItem
       <S.SelectBox $height={idx}>
         <S.DropDownBox
           $isClicked={clickedDropdown === 'service'}
-          onClick={() => (clickedDropdown ? setClickedDropdown(null) : setClickedDropdown('service'))}>
+          onClick={() => (clickedDropdown === 'service' ? setClickedDropdown(null) : setClickedDropdown('service'))}>
           <input type="button" value={serviceHistory.hairServiceRecords[idx].hairService || '시술  선택'} />
           {clickedDropdown === 'service' ? <IcUpBlue /> : <IcDownGrey />}
           {clickedDropdown === 'service' && (
@@ -64,7 +64,7 @@ const ServiceHistoryListItem = forwardRef<HTMLDivElement, ServiceHistoryListItem
       <S.SelectBox $height={idx}>
         <S.DropDownBox
           $isClicked={clickedDropdown === 'period'}
-          onClick={() => (clickedDropdown ? setClickedDropdown(null) : setClickedDropdown('period'))}>
+          onClick={() => (clickedDropdown === 'period' ? setClickedDropdown(null) : setClickedDropdown('period'))}>
           <input type="button" value={serviceHistory.hairServiceRecords[idx].hairServiceTerm || '기간  선택'} />
           {clickedDropdown === 'period' ? <IcUpBlue /> : <IcDownGrey />}
           {clickedDropdown === 'period' && (

--- a/src/views/ApplicationPage/components/ServiceHistoryListItem.tsx
+++ b/src/views/ApplicationPage/components/ServiceHistoryListItem.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { forwardRef, useState } from 'react';
 import { useRecoilState } from 'recoil';
 import { css, styled } from 'styled-components';
 
@@ -11,7 +11,7 @@ interface ServiceHistoryListItem {
   idx: number;
 }
 
-const ServiceHistoryListItem = ({ idx }: ServiceHistoryListItem) => {
+const ServiceHistoryListItem = forwardRef<HTMLDivElement, ServiceHistoryListItem>(({ idx }, ref) => {
   const [serviceHistory, setServiceHistory] = useRecoilState(historyState);
   const { hairServiceRecords } = serviceHistory;
   const [isServiceClicked, setIsServiceClicked] = useState(false);
@@ -60,9 +60,11 @@ const ServiceHistoryListItem = ({ idx }: ServiceHistoryListItem) => {
     <S.ServiceHistoryListItemLayout>
       <S.SelectBox $height={idx}>
         <S.SelectServiceBox
+          ref={ref}
           $isServiceClicked={isServiceClicked}
           onClick={() => {
             setIsServiceClicked((prev) => !prev);
+            console.log(ref);
           }}>
           <input
             type="button"
@@ -86,6 +88,7 @@ const ServiceHistoryListItem = ({ idx }: ServiceHistoryListItem) => {
       </S.SelectBox>
       <S.SelectBox $height={idx}>
         <S.SelectPeriodBox
+          ref={ref}
           $isPeriodClicked={isPeriodClicked}
           onClick={() => {
             setIsPeriodClicked((prev) => !prev);
@@ -117,7 +120,8 @@ const ServiceHistoryListItem = ({ idx }: ServiceHistoryListItem) => {
       </button>
     </S.ServiceHistoryListItemLayout>
   );
-};
+});
+ServiceHistoryListItem.displayName = 'ServiceHistoryListItem';
 
 const ServiceHistoryListItemLayout = styled.li`
   display: flex;

--- a/src/views/ApplicationPage/components/ServiceHistoryListItem.tsx
+++ b/src/views/ApplicationPage/components/ServiceHistoryListItem.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useRecoilState } from 'recoil';
 import { css, styled } from 'styled-components';
 
@@ -17,6 +17,10 @@ interface ServiceHistoryListItem {
 const ServiceHistoryListItem = ({ idx, currentDropDown, setCurrentDropDown }: ServiceHistoryListItem) => {
   const [serviceHistory, setServiceHistory] = useRecoilState(historyState);
   const [clickedDropdown, setClickedDropdown] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (currentDropDown !== idx) setClickedDropdown(null);
+  }, [currentDropDown]);
 
   const handleDropdownClick = (
     event: React.MouseEvent<HTMLButtonElement, MouseEvent>,
@@ -46,16 +50,14 @@ const ServiceHistoryListItem = ({ idx, currentDropDown, setCurrentDropDown }: Se
     <S.ServiceHistoryListItemLayout>
       <S.SelectBox $height={idx}>
         <S.DropDownBox
-          $isClicked={currentDropDown === idx && clickedDropdown === 'service'}
+          $isClicked={clickedDropdown === 'service'}
           onClick={() => {
             setCurrentDropDown(idx);
-            currentDropDown === idx && clickedDropdown === 'service'
-              ? setClickedDropdown(null)
-              : setClickedDropdown('service');
+            clickedDropdown === 'service' ? setClickedDropdown(null) : setClickedDropdown('service');
           }}>
           <input type="button" value={serviceHistory.hairServiceRecords[idx].hairService || '시술  선택'} />
-          {currentDropDown === idx && clickedDropdown === 'service' ? <IcUpBlue /> : <IcDownGrey />}
-          {currentDropDown === idx && clickedDropdown === 'service' && (
+          {clickedDropdown === 'service' ? <IcUpBlue /> : <IcDownGrey />}
+          {clickedDropdown === 'service' && (
             <S.SelectDetailList>
               {Object.keys(SELECT_SERVICE).map((value, key) => (
                 <li key={key}>
@@ -70,16 +72,14 @@ const ServiceHistoryListItem = ({ idx, currentDropDown, setCurrentDropDown }: Se
       </S.SelectBox>
       <S.SelectBox $height={idx}>
         <S.DropDownBox
-          $isClicked={currentDropDown === idx && clickedDropdown === 'period'}
+          $isClicked={clickedDropdown === 'period'}
           onClick={() => {
             setCurrentDropDown(idx);
-            currentDropDown === idx && clickedDropdown === 'period'
-              ? setClickedDropdown(null)
-              : setClickedDropdown('period');
+            clickedDropdown === 'period' ? setClickedDropdown(null) : setClickedDropdown('period');
           }}>
           <input type="button" value={serviceHistory.hairServiceRecords[idx].hairServiceTerm || '기간  선택'} />
-          {currentDropDown === idx && clickedDropdown === 'period' ? <IcUpBlue /> : <IcDownGrey />}
-          {currentDropDown === idx && clickedDropdown === 'period' && (
+          {clickedDropdown === 'period' ? <IcUpBlue /> : <IcDownGrey />}
+          {clickedDropdown === 'period' && (
             <S.SelectDetailList>
               {Object.keys(SELECT_PERIOD).map((value, key) => (
                 <li key={key}>


### PR DESCRIPTION
<!-- PR의 제목은 "[페이지명] 구현내용 " 으로, 연결되는 이슈 제목과 동일하게 가져가시면 됩니다! -->

![PR](https://github.com/TEAM-MODDY/moddy-web/assets/81505421/2d53d2e3-fcc8-4b65-835a-b118664382be)

## ▶️ Related Issue

- close #363

<br />

## ✅ Done Task
- 단일 드롭다운 활성화
- 드롭다운 외부 영역 클릭시 드롭다운 닫기
- 상태 관리 리팩토링

<br />

## 🔎 PR Point

<!-- 리뷰어에게 나의 코드를 설명해주세요 -->
### 💥 리팩토링 목표

이번 리팩토링의 목표는 **‘한 번에 하나의 드롭다운만 활성화되게 만들기’**입니다.
.![image](https://github.com/TEAM-MODDY/moddy-web/assets/101045330/10388ecb-fbb0-4642-96e7-8031e5c68d62)
얘처럼 와랄라 말고
![image](https://github.com/TEAM-MODDY/moddy-web/assets/101045330/be5b1f0b-5a20-4972-8730-b4ec51adefdb)
얘처럼 무조건 하나만 !

### 💥 하위 컴포넌트(`ServiceHistoryItem`)에서의 상태 관리

1. listItem 컴포넌트 내에서 state 두개를 하나로 전환 - period와 service 를 구분해주는 state / 함수도 하나로 통일

현재 `ServiceHistoryItem` 내부에서 왼쪽 드롭다운과 오른쪽 드롭다운을 구분해주기 위해 각각의 선택 여부를 `isServiceClicked`와 `isPeriodClicked`로 다루어주고 있는데 `clickedDropdown`이라는 하나의 상태로 통합해주었습니다 !

```tsx
const [clickedDropdown, setClickedDropdown] = useState<string | null>(null);

```

왼쪽 드롭다운을 클릭하면 `clickedDropdown`에 `service`라는 `string` 값이 저장되고 오른쪽 드롭다운을 클릭하면 `serviceTerm`이라는 `string` 값이 저장됩니다.

드롭다운 선택지를 클릭하면 전역 상태에 저장되게 하는 함수도 하나로 통합했습니다.

```tsx
const handleDropdownClick = (
    event: React.MouseEvent<HTMLButtonElement, MouseEvent>,
    field: 'hairService' | 'hairServiceTerm',
  ) => {
    const newValue = event.currentTarget.innerText;
    const newServiceHistoryRecords = serviceHistory.hairServiceRecords.map((item, i) => {
      if (i === idx) {
        return {
          ...item,
          [field]: newValue,
        };
      }
      return item;
    });

    setServiceHistory({ ...serviceHistory, hairServiceRecords: newServiceHistoryRecords });
    //클릭되면 다시 드롭다운 활성화 해제
		setClickedDropdown(null);
  };
```

### 💥 전체 드롭다운 컴포넌트 상태 관리

여러 가지 방법을 시도해보았는데 최종적으로는 상위 컴포넌트인 `ServiceHistory`에 `currentDropDown`이라는 상태를 추가해줘서 지금 활성화된 드롭다운 박스가 어느 `ServiceHistoryItem`에 포함된 박스인지 저장할 수 있도록 해주었습니당

```tsx
//상위 컴포넌트
const [currentDropDown, setCurrentDropDown] = useState<number | null>(null);

//하위 컴포넌트
<S.DropDownBox
  $isClicked={currentDropDown === idx && clickedDropdown === 'service'}
  onClick={() => {
    setCurrentDropDown(idx);
		...
```

### 💥 외부 영역 클릭시 드롭다운 선택 해제

수콩이 코드를 참고하다가 저도 욕심이 나서 기능을 추가했습니다.

```tsx
useEffect(() => {
    const handleFocus = (e: MouseEvent) => {
      if (historyRef.current && !historyRef.current.contains(e.target as Node)) setCurrentDropDown(null);
    };
    document.addEventListener('mouseup', handleFocus);

    return () => {
      document.removeEventListener('mouseup', handleFocus);
    };
}, [historyRef.current]);
```

시술 내역 리스트 외부 영역 클릭시 드롭다운 창이 닫힙니다.

### 💥 추가 코드 정리

상위 컴포넌트에서 드롭다운이 포함된 리스트가 선택 됐는지 여부를 받아오면서 조건문으로 드롭다운 활성화 여부를 체크해주었었는데  

```tsx
<S.SelectBox $height={idx}>
  <S.DropDownBox
    $isClicked={**currentDropDown === idx** && clickedDropdown === 'service'}
    onClick={() => {
      setCurrentDropDown(idx);
      **currentDropDown === idx** && clickedDropdown === 'service'
        ? setClickedDropdown(null)
        : setClickedDropdown('service');
    }}>
    <input type="button" value={serviceHistory.hairServiceRecords[idx].hairService || '시술  선택'} />
    {**currentDropDown === idx** && clickedDropdown === 'service' ? <IcUpBlue /> : <IcDownGrey />}
    {**currentDropDown === idx** && clickedDropdown === 'service' && (
      <S.SelectDetailList>
        {Object.keys(SELECT_SERVICE).map((value, key) => (
          <li key={key}>
            <button type="button" onClick={(e) => handleDropdownClick(e, 'hairService')}>
              {value}
            </button>
          </li>
        ))}
      </S.SelectDetailList>
    )}
  </S.DropDownBox>
</S.SelectBox>
```

`currentDropDown===idx`라는 조건문이 반복되고 있고 `currentDropDonw`이라는 `props`가 바뀔 때마다 새로 렌더링 되는 코드를 만들고 싶었기 때문에 아래와 같이 변경해주었습니다.

```tsx
//조건문 삭제 후, 추가
useEffect(() => {
    if (currentDropDown !== idx) setClickedDropdown(null);
  }, [currentDropDown]);
```

### 💥 고민 거리(였던 것)과 계획

위와 같은 과정으로 리팩토링을 하고 나니까 거슬리는 점이 하나 생겼었는데요,

> 각 리스트 컴포넌트들의 상태를 저장하는 상태인 `currentDropDown`과 리스트 내부에서 두 드롭다운을 구분해주는 용도로 사용하는 `clickedDropDown`을 하나의 상태로 통합해주는 건 안 될까 ?
>

아무래도 결국 전부 같은 드롭다운 컴포넌트이기 때문에 아예 공통 컴포넌트로 분리해서 `props`로 넘겨주는 값에 따라 다르게 렌더링되면 어떨까 ? 라는 생각이 들었습니당

그럼에도 불구하고 제가 **공통 컴포넌트로 분리하지 않은 이유**는

결국 각 리스트에 대한 정보를 삭제하는 과정을 위해서는 하위 컴포넌트의 상태를 상위 컴포넌트로 올려주는 `props drilling` 과정이 필수적으로 발생할 것 같기 때문입니다 !

지금 제 생각에는 이 정도의 컴포넌트 분리가 괜찮을 거 같기 때문에 이번 PR은 단일 드롭다운 활성화 정도로 마무리하겠습니다 ㅎㅎ 추후에 좀 더 괜찮은 방법이 생각난다면 드롭다운 컴포넌트를 공통 컴포넌트로 분리하는 걸로 - !

<br />

## 🧨 Trouble Shooting

<!-- 없으면 삭제 -->
수빈이가 처음에 `ref`를 이용해서 특정 영역 외 영역 선택시 작동하는 함수를 이용해 만드는 게 어떻냐고 추천해줬었는데 시도한 결과, 처참히 실패,,했습니다. 제가 생각한 첫번째 이유는

- 수빈이는 클릭 1번 → 하나의 컴포넌트 상태 값만 변화(모달 창 닫기)
- 저는 클릭 1번 → 다른 상태를 공유하는 두 컴포넌트의 상태 값 변화 (드롭다운 창 닫기 & 다른 드롭다운 창 키기)

두번째 이유는

- 상위 컴포넌트에서 받아온 ref를 사용할 때, 하위 컴포넌트에서 ref.current를 불러올 수가 없었던 문제

어떻게든 `ref`를 사용할까도 했는데 결국 렌더링을 유발해야해서 `state`를 사용하기로 결정했습니다.

<br />

## 📸 Screenshot

<!-- 없으면 삭제 -->
![moddy-Chrome2024-02-2004-38-07-ezgif com-video-to-gif-converter](https://github.com/TEAM-MODDY/moddy-web/assets/101045330/4cdbce2d-1c9f-4379-b174-433a65e879ba)
