### PR TITLE
[hotfix] 새로고침할 경우 accessToken이 안담기는 문제 해결 

### DIFF
--- a/src/views/@common/hooks/useSetInterceptors.ts
+++ b/src/views/@common/hooks/useSetInterceptors.ts
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useLayoutEffect } from 'react';
 
 import api from '../hooks/api';
 import usePostRefresh from '../hooks/usePostRefresh';
@@ -7,7 +7,7 @@ import { getToken } from '../utils/token';
 const useSetInterceptors = () => {
   const postRefresh = usePostRefresh();
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     api.interceptors.request.use((config) => {
       const accessToken = getToken();
       if (accessToken) {

--- a/src/views/@common/hooks/useSetInterceptors.ts
+++ b/src/views/@common/hooks/useSetInterceptors.ts
@@ -28,6 +28,11 @@ const useSetInterceptors = () => {
         return Promise.reject(err);
       },
     );
+
+    return () => {
+      api.interceptors.request.clear();
+      api.interceptors.response.clear();
+    };
   }, []);
 };
 export default useSetInterceptors;


### PR DESCRIPTION
<!-- PR의 제목은 "[페이지명] 구현내용 " 으로, 연결되는 이슈 제목과 동일하게 가져가시면 됩니다! -->

![PR](https://github.com/TEAM-MODDY/moddy-web/assets/81505421/2d53d2e3-fcc8-4b65-835a-b118664382be)

## ▶️ Related Issue

- close #388 

<br />

## ✅ Done Task
- [x] useEffect -> useLayoutEffect로 변경 
- [x] useLayoutEffect에 cleanup 코드 추가  

<br />

## 🧨 Trouble Shooting
### 🪫문제상황 
새로고침하면 메인페이지에서 자동으로 로그아웃 되고, 다른 페이지에서는 AccessToken이 없다는 에러가 발생했습니다
interceptors가 제 역할을 잘 못해주고 있다는 뜻인데요 
열심히 원인을 파악한 결과, 
최상위 라우트 컴포넌트인 Settings 내부의 useEffect보다, 자식 라우트인 다른 컴포넌트들의 내부에 있는 useEffect가 먼저 실행되어 
새로고침한 직후 axios interceptors를 세팅해주는 코드보다 각 페이지 로드 시 첫 get 통신이 먼저 실행되어서 토큰이 담기지 않아 생긴 문제였습니다. 

### 🔋해결책 
자식 컴포넌트의 useEffect가 부모 컴포넌트의 useEffect보다 먼저 실행되는 것은 리액트의 생명주기와 관련이 있는데요, 
useEffect는 컴포넌트가 마운트 된 후, 즉 DOM이 그려진 후에 실행되는 친구입니다. 
그럼 부모 컴포넌트의 useEffect는 부모 컴포넌트의 DOM이 그려진 후에 실행이 될테고, 
부모 컴포넌트의 DOM이 그려지는 과정에서 자식 컴포넌트들의 DOM이 그려지고 자식 컴포넌트들의 useEffect가 모두 실행될테니, 
그 이후에 부모 컴포넌트의 useEffect가 실행되는 방식인데요 

즉 현재상황에서 필요한 것은 **DOM이 그려지기 전에 코드가 실행되어야 한다** 였습니다. 
열심히 구글링을 해보니 해당 역할을 해주는 useLayoutEffect라는 훅이 있더라고요 
그래서 이 친구를 바로 적용해서 깔끔히 해결해주었습니다. 

[참고문헌](https://velog.io/@imphj3/React-useLayoutEffect-vs-useEffect-%EC%82%AC%EC%9A%A9%EB%B2%95) 
> useEffect는 컴포넌트들이 render 와 paint 된 후에 실행된다. 즉, 비동기적으로 DOM이 그려지고 난 후에 상태값에 따라 다시 렌더링된다. 따라서 useEffect 내부에 DOM에 영향을 주는 코드가 있을 경우 사용자는 화면의 깜빡임을 보게 된다.
> 
> 이러한 종류의 effect를 위해 React는 useLayoutEffect라는 추가적인 Hook을 제공한다. 이는 useEffect와 동일하게 사용할 수 있으며, 유일한 차이점은 **호출되는 시간**이다.
> 

> useLayoutEffect는 DOM이 그려지기 이전 시점에 동기적으로 수행된다. 즉 컴포넌트들이 render 된 후 실행되며, 그 이후에 paint 된다. paint가 되기 전에 실행되기 때문에 DOM을 조작하는 코드가 존재하더라도 사용자는 깜빡임을 경험하지 않는다.
>

### 🚀 useLayout cleanup 코드 
추가로, Setting 컴포넌트가 마운트될 때마다 axios instance에 interceptors가 여러개 계속 누적되고, 
이는 메모리 성능에 안좋은 영향을 끼칠 수 있다는 사실을 구글링 중에 알게되었습니다. 
그래서 useLayout cleanup 코드, 즉 return 문 내부에 
interceptors를 모두 삭제해주는 코드를 추가하여 
만약 Setting 컴포넌트가 다시 마운트될 일이 생겨도, 언마운트될 때 기존의 interceptors를 지워주고 다시 추가해줌으로써 
인터셉터는 계속해서 한개로 유지될 수 있도록 구현했습니다 

