### PR TITLE
[ApplicationPage] 지원 결과서 이미지 캡처 렌더링 문제 수정

### DIFF
--- a/src/recoil/atoms/applicationState.ts
+++ b/src/recoil/atoms/applicationState.ts
@@ -76,13 +76,7 @@ export const profileState = atom<profileType>({
   },
 });
 
-export interface imgDataType {
-  applicationCaptureImgUrl: File;
-}
-
-export const applicationCaptureImgUrlState = atom<imgDataType>({
+export const applicationCaptureImgUrlState = atom<File>({
   key: 'applicationCaptureImgUrl',
-  default: {
-    applicationCaptureImgUrl: new File([], 'empty.text'),
-  },
+  default: new File([], 'empty.text'),
 });

--- a/src/views/ApplicationPage/components/CaptureSection.tsx
+++ b/src/views/ApplicationPage/components/CaptureSection.tsx
@@ -30,7 +30,7 @@ const CaptureSection = () => {
     captureImage(ref.current).then((file) => {
       file && setImgData(file);
     });
-  }, [ref.current, setImgData]);
+  }, [ref.current]);
 
   const setLenghth = () => {
     switch (length) {

--- a/src/views/ApplicationPage/components/CaptureSection.tsx
+++ b/src/views/ApplicationPage/components/CaptureSection.tsx
@@ -4,8 +4,8 @@ import { styled } from 'styled-components';
 
 import { INFO_MESSAGE } from '../constants/message';
 import { SELECT_TYPE } from '../constants/select';
-import { captureImage } from '../hooks/useCaptureApplication';
 import useGetUser from '../hooks/useGetUser';
+import { captureImage } from '../utils/captureImage';
 
 import {
   applicationCaptureImgUrlState,

--- a/src/views/ApplicationPage/components/CaptureSection.tsx
+++ b/src/views/ApplicationPage/components/CaptureSection.tsx
@@ -1,13 +1,19 @@
-import React, { useRef } from 'react';
-import { useRecoilValue } from 'recoil';
+import React, { useEffect, useRef } from 'react';
+import { useRecoilValue, useSetRecoilState } from 'recoil';
 import { styled } from 'styled-components';
 
 import { INFO_MESSAGE } from '../constants/message';
 import { SELECT_TYPE } from '../constants/select';
-import { useCaptureApplication } from '../hooks/useCaptureApplication';
+import { captureImage } from '../hooks/useCaptureApplication';
 import useGetUser from '../hooks/useGetUser';
 
-import { deatiledStyleState, hairStyleState, historyState, profileState } from '@/recoil/atoms/applicationState';
+import {
+  applicationCaptureImgUrlState,
+  deatiledStyleState,
+  hairStyleState,
+  historyState,
+  profileState,
+} from '@/recoil/atoms/applicationState';
 
 const CaptureSection = () => {
   //지원서에 update할 state들
@@ -15,10 +21,16 @@ const CaptureSection = () => {
   const { length, preference } = useRecoilValue(hairStyleState);
   const detailedStyle = useRecoilValue(deatiledStyleState);
   const { hairServiceRecords } = useRecoilValue(historyState);
+  const setImgData = useSetRecoilState(applicationCaptureImgUrlState);
   const modelInfo = useGetUser();
 
   const ref = useRef<HTMLElement>(null);
-  useCaptureApplication(ref.current);
+
+  useEffect(() => {
+    captureImage(ref.current).then((file) => {
+      file && setImgData(file);
+    });
+  }, [ref.current, setImgData]);
 
   const setLenghth = () => {
     switch (length) {

--- a/src/views/ApplicationPage/hooks/useCaptureApplication.ts
+++ b/src/views/ApplicationPage/hooks/useCaptureApplication.ts
@@ -1,36 +1,24 @@
 import html2canvas from 'html2canvas';
-import { useEffect, useState } from 'react';
-import { useSetRecoilState } from 'recoil';
 
-import { applicationCaptureImgUrlState } from '@/recoil/atoms/applicationState';
+export const captureImage = async (ref: HTMLElement | null) => {
+  if (ref) {
+    const canvas = await html2canvas(ref);
+    if (canvas.height !== 0) {
+      const imgUrl = canvas.toDataURL();
+      downloadURL(imgUrl, 'test.png');
+      const response = await fetch(imgUrl);
+      const blob = await response.blob();
+      const file = new File([blob], 'captureApplication.png', { type: 'image/png' });
 
-export const useCaptureApplication = (ref: HTMLElement | null) => {
-  const [image, setImage] = useState<HTMLElement>();
-  const setImgData = useSetRecoilState(applicationCaptureImgUrlState);
-
-  useEffect(() => {
-    if (ref && !image) {
-      setImage(ref);
+      return file;
     }
-  }, [ref]);
-
-  useEffect(() => {
-    const captureImage = async () => {
-      if (image) {
-        const canvas = await html2canvas(image);
-        if (canvas.height !== 0) {
-          const imgUrl = canvas.toDataURL();
-          const response = await fetch(imgUrl);
-          const blob = await response.blob();
-          const file = new File([blob], 'captureApplication.png', { type: 'image/png' });
-
-          setImgData({ applicationCaptureImgUrl: file });
-        }
-      }
-    };
-
-    if (image) {
-      captureImage();
-    }
-  }, [image]);
+  }
 };
+
+function downloadURL(uri: string, name: string) {
+  const link = document.createElement('a');
+  link.download = name;
+  link.href = uri;
+  document.body.appendChild(link);
+  link.click();
+}

--- a/src/views/ApplicationPage/hooks/useCaptureApplication.ts
+++ b/src/views/ApplicationPage/hooks/useCaptureApplication.ts
@@ -4,23 +4,33 @@ import { useSetRecoilState } from 'recoil';
 
 import { applicationCaptureImgUrlState } from '@/recoil/atoms/applicationState';
 
-export const useCaptureApplication = async (ref: HTMLElement | null) => {
+export const useCaptureApplication = (ref: HTMLElement | null) => {
   const [image, setImage] = useState<HTMLElement>();
   const setImgData = useSetRecoilState(applicationCaptureImgUrlState);
 
   useEffect(() => {
-    ref && setImage(ref);
+    if (ref && !image) {
+      setImage(ref);
+    }
   }, [ref]);
 
-  if (image) {
-    const canvas = await html2canvas(image);
-    if (canvas.height !== 0) {
-      const imgUrl = canvas.toDataURL();
-      const response = await fetch(imgUrl);
-      const blob = await response.blob();
-      const file = new File([blob], 'captureApplication.png', { type: 'image/png' });
+  useEffect(() => {
+    const captureImage = async () => {
+      if (image) {
+        const canvas = await html2canvas(image);
+        if (canvas.height !== 0) {
+          const imgUrl = canvas.toDataURL();
+          const response = await fetch(imgUrl);
+          const blob = await response.blob();
+          const file = new File([blob], 'captureApplication.png', { type: 'image/png' });
 
-      setImgData({ applicationCaptureImgUrl: file });
+          setImgData({ applicationCaptureImgUrl: file });
+        }
+      }
+    };
+
+    if (image) {
+      captureImage();
     }
-  }
+  }, [image]);
 };

--- a/src/views/ApplicationPage/hooks/usePostApplication.ts
+++ b/src/views/ApplicationPage/hooks/usePostApplication.ts
@@ -20,7 +20,7 @@ const usePostApplication = () => {
   const hairDetail = useRecoilValue(deatiledStyleState);
   const { hairServiceRecords } = useRecoilValue(historyState);
   const { modelImgData, instagramId } = useRecoilValue(profileState);
-  const { applicationCaptureImgUrl } = useRecoilValue(applicationCaptureImgUrlState);
+  const applicationCaptureImgUrl = useRecoilValue(applicationCaptureImgUrlState);
 
   const tempHairServiceRecords = hairServiceRecords.map((element) => {
     const tempElement = { ...element };
@@ -56,7 +56,7 @@ const usePostApplication = () => {
 
     const requestbody = {
       modelImgUrl: modelImgData,
-      applicationCaptureImgUrl: applicationCaptureImgUrl,
+      applicationCaptureImgUrl,
       applicationInfo,
     };
 

--- a/src/views/ApplicationPage/utils/captureImage.ts
+++ b/src/views/ApplicationPage/utils/captureImage.ts
@@ -5,7 +5,6 @@ export const captureImage = async (ref: HTMLElement | null) => {
     const canvas = await html2canvas(ref);
     if (canvas.height !== 0) {
       const imgUrl = canvas.toDataURL();
-      downloadURL(imgUrl, 'test.png');
       const response = await fetch(imgUrl);
       const blob = await response.blob();
       const file = new File([blob], 'captureApplication.png', { type: 'image/png' });
@@ -14,11 +13,3 @@ export const captureImage = async (ref: HTMLElement | null) => {
     }
   }
 };
-
-function downloadURL(uri: string, name: string) {
-  const link = document.createElement('a');
-  link.download = name;
-  link.href = uri;
-  document.body.appendChild(link);
-  link.click();
-}


### PR DESCRIPTION
<!-- PR의 제목은 "[페이지명] 구현내용 " 으로, 연결되는 이슈 제목과 동일하게 가져가시면 됩니다! -->

![PR](https://github.com/TEAM-MODDY/moddy-web/assets/81505421/2d53d2e3-fcc8-4b65-835a-b118664382be)

이번엔 리스본 💚❤
![IMG_3787](https://github.com/TEAM-MODDY/moddy-web/assets/101045330/94426002-17b2-4366-bdfe-92e3baace4f7)
이쁘죠 ??? 이번 여행 최애 도시가 되었습니다
PR을 좀 더 빨리 날리고 싶었는데 관광하느라 지금 날리는 점,, 미안하구 이해 바랍니다 모비들아,,ㅎㅎ
<hr />

## ▶️ Related Issue

- close #345

<br />

## ✅ Done Task
- GET 무한 렌더링 오류 수정
- 훅 함수 유틸 함수로 분리

<br />

## 🔎 PR Point

<!-- 리뷰어에게 나의 코드를 설명해주세요 -->
합숙 때부터 골머리였던 GET 렌더링 이슈를 드디어 해결했습니다.
처음에 @lydiacho 의 도움을 받아서 코드를 짜느라 제 코드를 만드는 데에 시간이 걸렸던 거 같은데 **승희님이 해결하신 렌더링 이슈 방법**도 궁금합니다 ! ! ! 코멘트로 남겨주시거나 개인적으로 연락해주시면 감사하겠습니다 ㅎㅎ

### 렌더링 이슈 해결
캡처하는 영역을 상태에 저장하는 과정을 상위 컴포넌트에서 해결해주었습니다.
```tsx
//수정 전, 하위 컴포넌트
  useEffect(() => {
    ref && setImage(ref);
  }, [ref]);

//수정 후, 상위 컴포넌트
  useEffect(() => {
    captureImage(ref.current).then((file) => {
      file && setImgData(file);
    });
  }, [ref.current]);
```
`useRef`를 선언하면서부터 이미 객체를 만들어낸 상태이기 때문에 `ref`라는 객체는 항상 존재할 수 밖에 없는데 하위 컴포넌트에서 `ref`의 존재유무에 의해 리렌더링이 발생하도록 만들어놔서 무한 리렌더링이 발생하고 있다는 생각이 들었습니다.
그래서 의존성 배열 및 처리 로직을 위와 같이 조금씩 수정해주었습니다.

위의 코드에 의하면
![화면 캡처 2024-02-29 175820](https://github.com/TEAM-MODDY/moddy-web/assets/101045330/5ad1459e-158a-419e-b9a6-6ab71cc4cc8e)
`ref` 객체가 처음 잡혔을 때 1번, 모든 상태값 + 변수들이 다 paint된 후에 2번째로 렌더링이 일어납니다.
> 사실 첫번째 렌더링은 불필요하다는 생각이 들어서 해당 컴포넌트에서 GET 함수를 불러오는 과정이 끝난 다음에 캡처하는 함수가 불러와질 수 있는지 + 그러면 렌더링이 한 번만 발생하는지 확인해보고 싶다는 생각이 드네요 ! 성능이라 직결된 이슈라 일단 PR을 날려놓고 귀국해서 조금 더 건드려보겠습니당

### 함수 분리
원래는 지원서를 캡처하는 훅을 만들어서 제 컴포넌트에만 사용하고 있었는데요, 아무래도 화면 이미지를 캡처해주는 함수이기 때문에 (굳이 따지자면) **공통으로 사용하게 될 일이 생길 수도 있다 + 서버에 저장할 데이터로 만들어주는 과정까지 두 가지 역할을 할 필요는 없다** 라는 생각이 들어서 훅이 아닌 유틸 함수 `captureImg.ts`로 만들어주었습니다.


<br />

## 🧨 Trouble Shooting

<!-- 없으면 삭제 -->
### 문제 흐름
⚠️  `get` 무한 리렌더링 발생
무한 리렌더링이 발생한다는 뜻은 어떤 상태가 계속 변화하고 있다는 뜻인데 지원서 결과창 화면에서 사용하고 있는 `useCaptureApplication` 훅 뺴고는 리렌더링을 유발할 만한 곳이 없다고 판단했습니다. 그 중에서도 아래의 `useEffect`를 사용한 구문이 문제처럼 보였습니다.
```tsx
  useEffect(() => {
    ref && setImage(ref);
  }, [ref]);
```
**1️⃣ `useRef 문제`** 
`useRef`라는 훅을 사용해본 적이 많이 없어서 `ref` 객체를 `useEffect` 안에 넣으면 무한 리렌더링을 유발하나 싶었습니다.
→ 수통이가 `ref` 객체를 이용한 무한스크롤을 구현 시에도 서너번씩 렌더링이 얼어났다고 들어서 이런 의심을 해보았구요

결론: 하지만 `useRef`는 `ref` 객체가 변한다고 렌더링을 유발하지 않는걸 ❓❓❓
`useRef`를 처음 써보기도 하고 아직 잘 모르기 때문에 이런 오해가 생겼던 것 같아서 조금 자세하게 조사해보았습니당
[useRef](https://www.notion.so/useRef-12e0258255ad4145a2f0ec2729529199?pvs=21)

**2️⃣ 구문 내부의 setter 함수 문제**
`ref` 객체는 리렌더링을 유발하지 않는다. 그러면 위의 구문에서 리렌더링을 유발할 요소는,, `useEffect` 안의 `setter` 함수뿐 !
(실제로 테스트해봤을 때도 `setter` 함수를 제거하니 더이상 리렌더링이 발생하지 않았습니다.)

그래서 `setter` 함수를 사용하지 않고 값을 저장할 수 있는 방법은 없을까 고민을 많이 해봤는데요, 다른 태스크 작업을 하다가 생각을 해보니 `useEffet` 안에서 조건이나 의존성만 잘 걸어주면 리렌더링이 발생하지 않을 거 같다는 생각이 들었습니다.

**3️⃣ 의존성 배열 문제**
그래서 `useCaptureApplication` 훅 함수 내에서 이렇게 `useEffect` 함수를 이용해 의존성 배열을 다르게 해 상황마다 다르게 렌더링이 되도록 해주었습니다
```tsx
  useEffect(() => {
    ref && setImage(ref);
    if (ref && !image) {
      setImage(ref);
    }
  }, [ref]);

  useEffect(() => {
    const captureImage = async () => {
      if (image) {
        const canvas = await html2canvas(image);
        if (canvas.height !== 0) {
          const imgUrl = canvas.toDataURL();
          const response = await fetch(imgUrl);
          const blob = await response.blob();
          const file = new File([blob], 'captureApplication.png', { type: 'image/png' });

          setImgData({ applicationCaptureImgUrl: file });
        }
      }
    };
    if (image) {
      captureImage();
    }
  }, [image]);
};
```
다만, 마음에 걸렸던 게 
1️⃣ `useEffect`를 지양하려고 하는데 두 번이나 사용했다는 점
2️⃣ 훅 함수가 실행하는 코드가 또다른 훅 두개뿐이라는 점
때문에 현재와 같이 한 번 더 리팩토링을 진행해주었습니다,

<br />
