### PR TITLE
[MainPage] 지원하기 버튼에 팝업 추가

### DIFF
--- a/src/views/@common/hooks/useGetCheckApplication.ts
+++ b/src/views/@common/hooks/useGetCheckApplication.ts
@@ -1,0 +1,24 @@
+import { isAxiosError } from 'axios';
+import { useEffect, useState } from 'react';
+
+import api from './api';
+
+const useGetCheckApplication = () => {
+  const [status, setStatus] = useState(0);
+  const getCheckApplication = async () => {
+    try {
+      const response = await api.get('/application/check');
+      setStatus(response.status);
+    } catch (err) {
+      isAxiosError(err) && setStatus(err.response?.status || 0);
+    }
+  };
+
+  useEffect(() => {
+    getCheckApplication();
+  }, []);
+
+  return status;
+};
+
+export default useGetCheckApplication;

--- a/src/views/MainPage/components/TopSheet.tsx
+++ b/src/views/MainPage/components/TopSheet.tsx
@@ -1,10 +1,13 @@
+import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { styled } from 'styled-components';
 
 import { IcLogoHome, IcRightWhite, IcModdyuser } from '../assets/icons';
 import { APPLY_STATUS } from '../constants/applyStatus';
 
+import Modal from '@/views/@common/components/Modal';
 import { USER_TYPE } from '@/views/@common/constants/userType';
+import useGetCheckApplication from '@/views/@common/hooks/useGetCheckApplication';
 
 interface TopSheetProps {
   userType: string;
@@ -14,6 +17,8 @@ interface TopSheetProps {
 
 const TopSheet = (props: TopSheetProps) => {
   const { userType, applyType, name } = props;
+  const [isOpenModal, setIsOpenModal] = useState(false);
+  const status = useGetCheckApplication();
   const navigate = useNavigate();
 
   const OnBoardingText = () => {
@@ -69,27 +74,54 @@ const TopSheet = (props: TopSheetProps) => {
       <IcModdyuser />
     </button>
   );
+
+  const checkApplicationStatus = () => {
+    if (status === 200) {
+      return true;
+    }
+  };
+
+  const handleNavigate = () => {
+    if (userType === USER_TYPE.MODEL) {
+      checkApplicationStatus() ? setIsOpenModal(true) : navigate('/application');
+    } else if (userType === USER_TYPE.GUEST) {
+      navigate('/login');
+    }
+  };
+
   const StartButton = () => (
     <S.StartButton
       id={userType === USER_TYPE.GUEST ? 'ga-login-btn' : 'ga-application-btn'}
       type="button"
-      onClick={() => navigate(userType === USER_TYPE.GUEST ? '/login' : '/application')}>
+      onClick={() => handleNavigate()}>
       <S.StartButtonSpan>헤어 모델 지원하기{userType === USER_TYPE.GUEST && ' / 제안하기'}</S.StartButtonSpan>
       <IcRightWhite />
     </S.StartButton>
   );
 
   return (
-    <S.TopSheetLayout>
-      <S.HeaderBox>
-        <IcLogoHome />
-        {userType === USER_TYPE.GUEST ? <LoginButton /> : <MyPageButton />}
-      </S.HeaderBox>
-      <S.OnBoardingBox>
-        <OnBoardingText />
-      </S.OnBoardingBox>
-      {userType !== USER_TYPE.DESIGNER && <StartButton />}
-    </S.TopSheetLayout>
+    <>
+      <S.TopSheetLayout>
+        <S.HeaderBox>
+          <IcLogoHome />
+          {userType === USER_TYPE.GUEST ? <LoginButton /> : <MyPageButton />}
+        </S.HeaderBox>
+        <S.OnBoardingBox>
+          <OnBoardingText />
+        </S.OnBoardingBox>
+        {userType !== USER_TYPE.DESIGNER && <StartButton />}
+      </S.TopSheetLayout>
+      {isOpenModal ? (
+        <Modal
+          title="새로운 지원서를 등록할까요?"
+          description="현재 지원서에<br/>등록된 내용은 사라져요"
+          leftBtnText="취소"
+          rightBtnText="확인"
+          leftBtnFn={() => setIsOpenModal(false)}
+          rightBtnFn={() => navigate('/application')}
+        />
+      ) : null}
+    </>
   );
 };
 


### PR DESCRIPTION
<!-- PR의 제목은 "[페이지명] 구현내용 " 으로, 연결되는 이슈 제목과 동일하게 가져가시면 됩니다! -->

![PR](https://github.com/TEAM-MODDY/moddy-web/assets/81505421/2d53d2e3-fcc8-4b65-835a-b118664382be)

## ▶️ Related Issue

- close #396

<br />

## ✅ Done Task
- /application/check api hook 생성
- 지원서 상태에 따라 모달 띄우기 / navigate 로직 추가

<br />

## 🔎 PR Point

<!-- 리뷰어에게 나의 코드를 설명해주세요 -->
### 공통 훅 추가 👩🏻‍🍳

`/application/check` 에 해당하는 통신을 mypage에서도 사용하기 때문에
`@common/hooks/useGetCheckApplication.ts`에 넣어뒀습니다

해당 훅은 통신 상태 코드를 반환합니다 

> `200` -> 유효한 지원서
> `404` -> 유효하지 않은 지원서 (지원서를 작성한 적 없음, 만료된 지원서 )

저는 확장가능성 (후에 더 많은 상태를 가지게 될 수 도 있음) 을 고려하여 `상태코드를 그대로 반환` 하도록 하였는데
현재는 유효함/유효하지 않음을 판단하기에 `true / false로 반환` 하는 것이 좋을 지 고민을 하였습니다.

**🚀 이 부분에 대해서 어떻게 생각하시는지 궁금합니다 !!**


<br />


## 📸 Screenshot

### 지원서가 유효하지 않는 경우
바로 지원 페이지로 넘어감
https://github.com/TEAM-MODDY/moddy-web/assets/46593078/8f827fe8-a0d7-46c4-990d-3fde692bdb29

### 지원서가 유효한 경우
새 지원서 작성 모달을 띄우고 확인했을 때 지원 페이지로 넘어감
https://github.com/TEAM-MODDY/moddy-web/assets/46593078/33dd7e21-3ebc-439f-99fa-4522c3b8ccdb


