### PR TITLE
[SignUpPage] 회원가입 중단 시 모달 워딩 변경

### DIFF
--- a/src/views/@common/components/Header.tsx
+++ b/src/views/@common/components/Header.tsx
@@ -42,10 +42,10 @@ const Header = ({ isBackBtnExist, isCloseBtnExist, title, backFn, closeFn, isNoM
       </S.HeaderBox>
       {isOpenModal && (
         <Modal
-          title="작성을 취소하시겠습니까?"
-          description="지금 작성을 취소하면<br/>작성 중인 내용이 사라져요."
-          leftBtnText="계속하기"
-          rightBtnText="취소하기"
+          title="작성을 중단할까요?"
+          description="작성 중인 내용이 사라져요."
+          leftBtnText="취소"
+          rightBtnText="확인"
           leftBtnFn={() => setOpenModal(false)}
           rightBtnFn={() => (closeFn ? closeFn() : navigate('/'))}
         />


### PR DESCRIPTION
<!-- PR의 제목은 "[페이지명] 구현내용 " 으로, 연결되는 이슈 제목과 동일하게 가져가시면 됩니다! -->

![PR](https://github.com/TEAM-MODDY/moddy-web/assets/81505421/2d53d2e3-fcc8-4b65-835a-b118664382be)

## ▶️ Related Issue

- close #406 

<br />

## ✅ Done Task
- 워딩 변경

<br />

## 🔎 PR Point

<!-- 리뷰어에게 나의 코드를 설명해주세요 -->
반영 중에 이 모달이 회원가입 중단 시에만 사용하는 것이 아니라 다른 곳에서도 사용되고 있더라고요,
그런데 지금 해당 모달이 공통 컴포넌트 Header에 들어 있습니다
**그런데 X를 누르더라도 다른 모달이 뜨는 경우가 있을 수 있을 것 같습니다**
(현재는 모든 header의 x 버튼을 눌렀을 때 작성을 중단할까요? 모달이긴 하지만요)
그래서 **이 모달은 header에 closeFn을 이용해서 사용하는 컴포넌트에서 불러야하는게 맞지 않을까?** 라는 생각이 들었습니다
**다른 분들도 의견 주시면 감사하겠습니다 🚀**
만약 해당 방식으로 바꾸는 것에 다들 찬성한다면 리팩토링 기간에 고쳐보면 좋을 것 같습니다! (저만 바꾸면 되는게 아니라..)

<br />

## 📸 Screenshot

<!-- 없으면 삭제 -->
<img width="314" alt="스크린샷 2024-03-06 오전 10 40 16" src="https://github.com/TEAM-MODDY/moddy-web/assets/46593078/9f485e80-d0c3-4ac4-a727-3761c4936e46">
