### PR TITLE
[ApplicationPage] 지원서 만료 예정 정보 추가

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,8 +3,8 @@ import { RecoilRoot } from 'recoil';
 import { ThemeProvider } from 'styled-components';
 
 import AgreementPage from './pages/AgreementPage';
+import ApplicationConfirmPage from './pages/ApplicationConfirmPage';
 import ApplicationPage from './pages/ApplicationPage';
-import ConfirmPage from './pages/ConfirmPage';
 import ErrorPage from './pages/ErrorPage';
 import LoginPage from './pages/LoginPage';
 import MainPage from './pages/MainPage';
@@ -38,7 +38,7 @@ const router = createBrowserRouter([
       { path: '/offer-info/check-offer', element: <CheckOfferPage /> },
       { path: '/my-quit', element: <MyQuitPage /> },
       { path: '/model-info/model-offer', element: <ModelOfferPage /> },
-      { path: '/application/confirm', element: <ConfirmPage /> },
+      { path: '/application/confirm', element: <ApplicationConfirmPage /> },
       { path: '/agreement', element: <AgreementPage /> },
       { path: '/model-info/model-offer/sent-complete', element: <OfferSentCompletePage /> },
       { path: '/error', element: <ErrorPage /> },

--- a/src/pages/ApplicationConfirmPage.tsx
+++ b/src/pages/ApplicationConfirmPage.tsx
@@ -1,4 +1,4 @@
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { styled } from 'styled-components';
 
 import Button from '../views/@common/components/Button';
@@ -8,6 +8,9 @@ import ImgLetter from '@images/img_letter.png';
 
 const ApplicationConfirmPage = () => {
   const navigate = useNavigate();
+  const {
+    state: { expireDate },
+  } = useLocation();
 
   return (
     <S.ConfirmPage>
@@ -20,7 +23,11 @@ const ApplicationConfirmPage = () => {
           ))}
         </S.Description>
       </S.ConfirmInfoSection>
-      <S.ExpiredInfoBox>{INFO_MESSAGE.CONFIRM_EXPIRED}</S.ExpiredInfoBox>
+      <S.ExpiredInfoBox>
+        {INFO_MESSAGE.CONFIRM_EXPIRED}
+        {expireDate}
+        {expireDate}
+      </S.ExpiredInfoBox>
       <Button
         text={INFO_MESSAGE.CLOSE}
         isFixed={true}

--- a/src/pages/ApplicationConfirmPage.tsx
+++ b/src/pages/ApplicationConfirmPage.tsx
@@ -9,7 +9,7 @@ import ImgLetter from '@images/img_letter.png';
 const ApplicationConfirmPage = () => {
   const navigate = useNavigate();
   const {
-    state: { expireDate },
+    state: { expirationDate },
   } = useLocation();
 
   return (
@@ -25,11 +25,11 @@ const ApplicationConfirmPage = () => {
       </S.ConfirmInfoSection>
       <S.ExpiredInfoBox>
         {INFO_MESSAGE.CONFIRM_EXPIRED} <br />
-        {expireDate} ~ {expireDate}
+        {expirationDate}
       </S.ExpiredInfoBox>
       <Button
-        text={INFO_MESSAGE.CLOSE}
-        isFixed={true}
+        text={INFO_MESSAGE.CONFIRM}
+        isFixed={false}
         onClickFn={() => {
           navigate(`/`);
         }}
@@ -44,18 +44,17 @@ const S = {
   ConfirmPage: styled.main`
     display: flex;
     flex-direction: column;
-    gap: 5.443rem;
-    justify-content: center;
+    justify-content: flex-end;
     align-items: center;
 
     width: 100%;
     height: 100dvh;
-    padding: 0 1.55rem;
 
     & > img {
       overflow: hidden;
 
       width: 19.5rem;
+      margin-bottom: 5.443rem;
       border-radius: 8px;
 
       box-shadow: ${({ theme }) => theme.effects.graphic};
@@ -70,6 +69,8 @@ const S = {
     gap: 0.8rem;
     align-items: center;
 
+    margin-bottom: 6.35rem;
+
     & > h1 {
       color: ${({ theme }) => theme.colors.moddy_bk};
 
@@ -78,7 +79,8 @@ const S = {
   `,
 
   ExpiredInfoBox: styled.div`
-    width: 100%;
+    width: calc(100% - 3.1rem);
+    margin-bottom: 1.6rem;
     padding: 1.3rem 0;
     border-radius: 10px;
 

--- a/src/pages/ApplicationConfirmPage.tsx
+++ b/src/pages/ApplicationConfirmPage.tsx
@@ -6,7 +6,7 @@ import Button from '../views/@common/components/Button';
 import { INFO_MESSAGE } from '@/views/ApplicationPage/constants/message';
 import ImgLetter from '@images/img_letter.png';
 
-const ConfirmPage = () => {
+const ApplicationConfirmPage = () => {
   const navigate = useNavigate();
 
   return (
@@ -31,7 +31,7 @@ const ConfirmPage = () => {
   );
 };
 
-export default ConfirmPage;
+export default ApplicationConfirmPage;
 
 const S = {
   ConfirmPage: styled.main`

--- a/src/pages/ApplicationConfirmPage.tsx
+++ b/src/pages/ApplicationConfirmPage.tsx
@@ -24,9 +24,8 @@ const ApplicationConfirmPage = () => {
         </S.Description>
       </S.ConfirmInfoSection>
       <S.ExpiredInfoBox>
-        {INFO_MESSAGE.CONFIRM_EXPIRED}
-        {expireDate}
-        {expireDate}
+        {INFO_MESSAGE.CONFIRM_EXPIRED} <br />
+        {expireDate} ~ {expireDate}
       </S.ExpiredInfoBox>
       <Button
         text={INFO_MESSAGE.CLOSE}
@@ -51,12 +50,12 @@ const S = {
 
     width: 100%;
     height: 100dvh;
-    padding: 9rem;
+    padding: 0 1.55rem;
 
     & > img {
       overflow: hidden;
 
-      width: 100%;
+      width: 19.5rem;
       border-radius: 8px;
 
       box-shadow: ${({ theme }) => theme.effects.graphic};
@@ -79,11 +78,14 @@ const S = {
   `,
 
   ExpiredInfoBox: styled.div`
+    width: 100%;
+    padding: 1.3rem 0;
     border-radius: 10px;
 
     background-color: ${({ theme }) => theme.colors.moddy_gray05};
 
     color: ${({ theme }) => theme.colors.moddy_gray50};
+    text-align: center;
 
     ${({ theme }) => theme.fonts.Body04};
   `,

--- a/src/pages/ApplicationConfirmPage.tsx
+++ b/src/pages/ApplicationConfirmPage.tsx
@@ -12,14 +12,15 @@ const ApplicationConfirmPage = () => {
   return (
     <S.ConfirmPage>
       <img src={ImgLetter} alt="letterImg" />
-      <S.Info>
+      <S.ConfirmInfoSection>
         <h1>{INFO_MESSAGE.CONFIRM_TITLE}</h1>
         <S.Description>
           {INFO_MESSAGE.CONFIRM_SUBTITLE.split('<br />').map((line: string) => (
             <p key={line}>{line}</p>
           ))}
         </S.Description>
-      </S.Info>
+      </S.ConfirmInfoSection>
+      <S.ExpiredInfoBox>{INFO_MESSAGE.CONFIRM_EXPIRED}</S.ExpiredInfoBox>
       <Button
         text={INFO_MESSAGE.CLOSE}
         isFixed={true}
@@ -57,7 +58,7 @@ const S = {
     }
   `,
 
-  Info: styled.section`
+  ConfirmInfoSection: styled.section`
     display: flex;
     flex-direction: column;
     gap: 0.8rem;
@@ -69,6 +70,17 @@ const S = {
       ${({ theme }) => theme.fonts.Title01};
     }
   `,
+
+  ExpiredInfoBox: styled.div`
+    border-radius: 10px;
+
+    background-color: ${({ theme }) => theme.colors.moddy_gray05};
+
+    color: ${({ theme }) => theme.colors.moddy_gray50};
+
+    ${({ theme }) => theme.fonts.Body04};
+  `,
+
   Description: styled.div`
     & > p {
       color: ${({ theme }) => theme.colors.moddy_gray50};

--- a/src/views/ApplicationPage/components/ApplicationResult.tsx
+++ b/src/views/ApplicationPage/components/ApplicationResult.tsx
@@ -43,7 +43,6 @@ const ApplicationResult = () => {
   const handleApplication = async () => {
     try {
       await postApplication();
-      navigate(`/application/confirm`);
       resetAtom();
     } catch (err) {
       navigate('/error');

--- a/src/views/ApplicationPage/constants/message.ts
+++ b/src/views/ApplicationPage/constants/message.ts
@@ -1,8 +1,8 @@
 export const INFO_MESSAGE = {
-  TITLE: '모델 지원하기',
+  TITLE: '모델 지원',
   NEXT: '다음',
   LAST: '완료',
-  CLOSE: '닫기',
+  CONFIRM: '확인',
 
   LENGTH_TITLE: '머리 기장',
   LENGTH_SUBTITLE: '현재 머리 기장을 선택해주세요',

--- a/src/views/ApplicationPage/constants/message.ts
+++ b/src/views/ApplicationPage/constants/message.ts
@@ -38,4 +38,5 @@ export const INFO_MESSAGE = {
 
   CONFIRM_TITLE: '헤어모델 지원 완료!',
   CONFIRM_SUBTITLE: '내게 딱 맞는 헤어디자이너의 제안서가<br />곧 도착할 예정이에요.',
+  CONFIRM_EXPIRED: '지금 작성한 지원서는 아래 7일간 유효해요',
 };

--- a/src/views/ApplicationPage/hooks/usePostApplication.ts
+++ b/src/views/ApplicationPage/hooks/usePostApplication.ts
@@ -61,9 +61,14 @@ const usePostApplication = () => {
     };
 
     try {
-      await api.post('/application', requestbody, {
+      const { data } = await api.post('/application', requestbody, {
         headers: {
           'Content-Type': 'multipart/form-data',
+        },
+      });
+      navigate(`/application/confirm`, {
+        state: {
+          expireDate: data.expireDate,
         },
       });
     } catch (err) {

--- a/src/views/ApplicationPage/hooks/usePostApplication.ts
+++ b/src/views/ApplicationPage/hooks/usePostApplication.ts
@@ -68,7 +68,7 @@ const usePostApplication = () => {
       });
       navigate(`/application/confirm`, {
         state: {
-          expireDate: data.expireDate,
+          expireDate: data.data.expireDate,
         },
       });
     } catch (err) {

--- a/src/views/ApplicationPage/hooks/usePostApplication.ts
+++ b/src/views/ApplicationPage/hooks/usePostApplication.ts
@@ -68,7 +68,7 @@ const usePostApplication = () => {
       });
       navigate(`/application/confirm`, {
         state: {
-          expireDate: data.data.expireDate,
+          expirationDate: data.data.expirationDate,
         },
       });
     } catch (err) {


### PR DESCRIPTION
<!-- PR의 제목은 "[페이지명] 구현내용 " 으로, 연결되는 이슈 제목과 동일하게 가져가시면 됩니다! -->

![PR](https://github.com/TEAM-MODDY/moddy-web/assets/81505421/2d53d2e3-fcc8-4b65-835a-b118664382be)

## ▶️ Related Issue

- close #410

<br />

## ✅ Done Task
- ResponseBody로 전달오는 지원서 만료 예정 정보 추가

<br />

## 🔎 PR Point

<!-- 리뷰어에게 나의 코드를 설명해주세요 -->
`usePostApplication`으로 `ApplicationPage`에서 서버와 통신하고 있었는데 `ApplicationConfirmPage`에서 서버의 ResponseBody로 전달오는 정보를 불러와야하는 상황이 발생했습니다.
```tsx
//ApplicationPage에서 서버 통신시 실행 구문
  navigate(`/application/confirm`, {
    state: {
      expireDate: data.data.expireDate,
    },
  });

//ApplicationConfirmPage
  const {
    state: { expireDate },
  } = useLocation();
```
다음과 같이 `useNavigate`훅의 `state`에 정보값을 저장해서 만료 날짜를 불러올 수 있게 만들어주었습니다 !

<br />

## 📸 Screenshot

<!-- 없으면 삭제 -->
![image](https://github.com/TEAM-MODDY/moddy-web/assets/101045330/81dd319e-ec6b-4df2-af38-755d619e6de7)
