### PR TITLE
[ApplicationPage] 이미지 용량 초과시 업로드 제한 및 모달 출현 공통 컴포넌트 적용

### DIFF
--- a/src/pages/ApplicationPage.tsx
+++ b/src/pages/ApplicationPage.tsx
@@ -5,7 +5,7 @@ import { applyStepState } from '@/recoil/atoms/applicationState';
 import ApplicationResult from '@/views/ApplicationPage/components/ApplicationResult';
 import DefaultInfo from '@/views/ApplicationPage/components/DefaultInfo';
 import DetailedStyle from '@/views/ApplicationPage/components/DetailedStyle';
-import ProfileUpload from '@/views/ApplicationPage/components/ProfileUpload';
+import Profile from '@/views/ApplicationPage/components/Profile';
 import ServiceHistory from '@/views/ApplicationPage/components/ServiceHistory';
 import { STEP } from '@/views/ApplicationPage/constants/step';
 
@@ -21,7 +21,7 @@ const ApplicationPage = () => {
       case STEP.SERVICE_HISTORY:
         return <ServiceHistory />;
       case STEP.PROFILE:
-        return <ProfileUpload />;
+        return <Profile />;
       case STEP.RESULT:
         return <ApplicationResult />;
     }

--- a/src/views/ApplicationPage/components/Profile.tsx
+++ b/src/views/ApplicationPage/components/Profile.tsx
@@ -1,41 +1,34 @@
-import { useRef, useState } from 'react';
+import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useRecoilState } from 'recoil';
 import { styled } from 'styled-components';
 
 import { IcEssential } from '../../@common/assets/icons';
-import beforeUpload from '../../@common/assets/images/img_photoadd_profile.png';
 import Button from '../../@common/components/Button';
 import Header from '../../@common/components/Header';
 import Input from '../../@common/components/Input';
 import ProgressBar from '../../@common/components/ProgressBar';
-import { IcPencilcircle } from '../assets/icons';
 import { INFO_MESSAGE } from '../constants/message';
-import { readImg } from '../utils/readImg';
 
 import { applyStepState, profileState } from '@/recoil/atoms/applicationState';
+import ProfileUpload from '@/views/@common/components/ProfileUpload';
+import ToastMessage from '@/views/@common/components/ToastMessage';
 import { REGEX } from '@/views/@common/utils/regex';
 
-const ProfileUpload = () => {
-  const inputRef = useRef<HTMLInputElement>(null);
+const Profile = () => {
+  const [isToastOpen, setToastOpen] = useState(false);
   const [step, setStep] = useRecoilState(applyStepState);
   const [profileData, setProfileData] = useRecoilState(profileState);
   const [isAllVerified, setIsAllVerified] = useState(false);
   const navigate = useNavigate();
 
-  const handleProfileImg = (event: React.ChangeEvent<HTMLInputElement>) => {
-    readImg(event)
-      .then((dataUrl) => {
-        setProfileData({
-          ...profileData,
-          modelImgUrl: dataUrl.previewSrc,
-          modelImgData: dataUrl.imgUrl,
-        });
-        setIsAllVerified(true);
-      })
-      .catch(() => {
-        navigate('/error');
-      });
+  const handleProfileImg = (imgUrl: string, imgObj: File) => {
+    setProfileData({
+      ...profileData,
+      modelImgUrl: imgUrl,
+      modelImgData: imgObj,
+    });
+    setIsAllVerified(true);
   };
 
   const handleInstagramId = (e: string) => {
@@ -46,7 +39,7 @@ const ProfileUpload = () => {
   };
 
   return (
-    <S.ProfileUploadLayout>
+    <S.ProfileLayout>
       <Header
         title="모델 지원하기"
         isBackBtnExist={true}
@@ -69,28 +62,9 @@ const ProfileUpload = () => {
               <span key={line}>{line}</span>
             ))}
           </S.Title>
-          <S.ProfileUploadBtnBox>
-            <S.ProfileUploadBtn
-              type="button"
-              onClick={() => {
-                inputRef.current?.click();
-              }}>
-              <S.Profile
-                src={profileData.modelImgUrl ? profileData.modelImgUrl : beforeUpload}
-                alt="profileImg"
-                id="profileImg"
-              />
-              <input
-                id="uploadButton"
-                name="uploadButton"
-                ref={inputRef}
-                type="file"
-                accept="image/*"
-                onChange={handleProfileImg}
-              />
-              <IcPencilcircle />
-            </S.ProfileUploadBtn>
-          </S.ProfileUploadBtnBox>
+          <S.ProfileBtnBox>
+            <ProfileUpload onImageUpload={handleProfileImg} setToastOpen={setToastOpen} />
+          </S.ProfileBtnBox>
         </S.ProfilePhotoSection>
         <S.ProfileInstaSection>
           <S.Title>
@@ -112,12 +86,19 @@ const ProfileUpload = () => {
         }}
         disabled={!isAllVerified}
       />
-    </S.ProfileUploadLayout>
+      {isToastOpen && (
+        <ToastMessage
+          text={INFO_MESSAGE.CAPACITY_WARNING}
+          subtext={INFO_MESSAGE.CAPACITY_SUBWARNING}
+          setter={setToastOpen}
+        />
+      )}
+    </S.ProfileLayout>
   );
 };
 
 const S = {
-  ProfileUploadLayout: styled.section`
+  ProfileLayout: styled.section`
     display: flex;
     flex-direction: column;
     justify-content: space-between;
@@ -143,7 +124,7 @@ const S = {
     gap: 3.7rem;
   `,
 
-  ProfileUploadBtnBox: styled.div`
+  ProfileBtnBox: styled.div`
     position: relative;
 
     width: 13.2rem;
@@ -153,7 +134,7 @@ const S = {
     cursor: pointer;
   `,
 
-  ProfileUploadBtn: styled.button`
+  ProfileBtn: styled.button`
     width: 100%;
     height: 100%;
     border: 1.5px dashed ${({ theme }) => theme.colors.moddy_blue2};
@@ -207,4 +188,4 @@ const S = {
   `,
 };
 
-export default ProfileUpload;
+export default Profile;

--- a/src/views/ApplicationPage/constants/message.ts
+++ b/src/views/ApplicationPage/constants/message.ts
@@ -25,6 +25,9 @@ export const INFO_MESSAGE = {
   INSTA_SUBTITLE: '평소 스타일 파악을 위해 입력을 권장드려요',
   INSTA_INPUT: "아이디를 입력해주세요 ('@' 제외)",
 
+  CAPACITY_WARNING: '사진 용량이 너무 커요!',
+  CAPACITY_SUBWARNING: '5MB 이하의 사진을 올려주세요',
+
   FINAL_TITLE: '최종 확인',
   MODEL_INFO: '모델 정보',
   INFO_NAME: '이름',


### PR DESCRIPTION
<!-- PR의 제목은 "[페이지명] 구현내용 " 으로, 연결되는 이슈 제목과 동일하게 가져가시면 됩니다! -->

![PR](https://github.com/TEAM-MODDY/moddy-web/assets/81505421/2d53d2e3-fcc8-4b65-835a-b118664382be)

## ▶️ Related Issue

- close #414

<br />

## ✅ Done Task
- 기존 컴포넌트를 공통 컴포넌트로 교체

<br />

## 🔎 PR Point

<!-- 리뷰어에게 나의 코드를 설명해주세요 -->
민서가 만들어준 공통 컴포넌트를 쇽샥해서 제 페이지에 적용시켜놓았습니다.

💭별다른 PR point는 없지만 이렇게 해주면서 민서와 저의 `프로필 업로드` 관련 컴포넌트가 `input` 박스 하나의 유무를 제외하고는 동일해졌습니다.
그래서 차후 다시 있을 리팩 기간에 분기 처리하는 방식을 사용해서 하나의 컴포넌트로 합칠까 합니다 !

추가로 어제 민서와 요 프로필 업로드 컴포넌트에 대해 이야기하면서 서버와 통신 완료~ 했다는 안내를 띄워주는 `confirm 페이지`를 수빈이가 저번에 미미나 열어준 합성 컴포넌트 방식으로 구현하면 어떨까 해서 의견을 제시해 봤는데요 ! ! ! 구현하게 된다면 PR 올리겠습니당
(똑같이 디자이너일 때와 모델일 때로 분기 처리를 하지 않을까 싶습니다 ㅎㅎ)

<br />

## 📸 Screenshot

<!-- 없으면 삭제 -->
![image](https://github.com/TEAM-MODDY/moddy-web/assets/101045330/0803c988-03a3-462b-8017-c5ca8a6c265f)
