### PR TITLE
[ApplicationmPage] 시술 내역 경고 모달창 추가

### DIFF
--- a/src/recoil/atoms/applicationState.ts
+++ b/src/recoil/atoms/applicationState.ts
@@ -43,7 +43,7 @@ export interface historyDetailProps {
 }
 
 export interface historyType {
-  hairServiceRecords: Array<historyDetailProps>;
+  hairServiceRecords: historyDetailProps[];
   hairService: string;
   hairServiceTerm: string;
 }

--- a/src/views/ApplicationPage/components/ServiceHistory.tsx
+++ b/src/views/ApplicationPage/components/ServiceHistory.tsx
@@ -11,10 +11,12 @@ import ServiceHistoryListItem from './ServiceHistoryListItem';
 
 import { applyStepState, historyState } from '@/recoil/atoms/applicationState';
 import ProgressBar from '@/views/@common/components/ProgressBar';
+import ToastMessage from '@/views/@common/components/ToastMessage';
 
 const ServiceHistory = () => {
   const MAX_LENGTH = 3;
 
+  const [isToastOpen, setToastOpen] = useState(false);
   const [step, setStep] = useRecoilState(applyStepState);
   const [serviceHistory, setServiceHistory] = useRecoilState(historyState);
   const [currentDropDown, setCurrentDropDown] = useState<number | null>(null);
@@ -42,12 +44,11 @@ const ServiceHistory = () => {
     }));
   };
 
-  const exceptionNull = () => {
-    if (
-      serviceHistory.hairServiceRecords[0].hairService === '' ||
-      serviceHistory.hairServiceRecords[0].hairServiceTerm === ''
-    )
-      setServiceHistory({ ...serviceHistory, hairServiceRecords: [] });
+  const isHistoryFilled = () => {
+    const notEmpty = serviceHistory.hairServiceRecords.every((element) => {
+      return element.hairService !== '' && element.hairServiceTerm !== '';
+    });
+    notEmpty ? setStep({ ...step, current: step.current + 1 }) : setToastOpen(true);
   };
 
   return (
@@ -85,10 +86,10 @@ const ServiceHistory = () => {
         text={INFO_MESSAGE.NEXT}
         isFixed={true}
         onClickFn={() => {
-          setStep({ ...step, current: step.current + 1 });
-          exceptionNull();
+          isHistoryFilled();
         }}
       />
+      {isToastOpen && <ToastMessage text={INFO_MESSAGE.FILLED_FORM_TITLE} setter={setToastOpen} />}
     </S.ServiceHistoryLayout>
   );
 };

--- a/src/views/ApplicationPage/components/ServiceHistoryListItem.tsx
+++ b/src/views/ApplicationPage/components/ServiceHistoryListItem.tsx
@@ -48,13 +48,13 @@ const ServiceHistoryListItem = ({ idx, currentDropDown, setCurrentDropDown }: Se
 
   return (
     <S.ServiceHistoryListItemLayout>
-      <S.SelectBox $height={idx}>
-        <S.DropDownBox
-          $isClicked={clickedDropdown === 'service'}
-          onClick={() => {
-            setCurrentDropDown(idx);
-            clickedDropdown === 'service' ? setClickedDropdown(null) : setClickedDropdown('service');
-          }}>
+      <S.SelectBox
+        $height={idx}
+        onClick={() => {
+          setCurrentDropDown(idx);
+          clickedDropdown === 'service' ? setClickedDropdown(null) : setClickedDropdown('service');
+        }}>
+        <S.DropDownBox $isClicked={clickedDropdown === 'service'}>
           <input type="button" value={serviceHistory.hairServiceRecords[idx].hairService || '시술  선택'} />
           {clickedDropdown === 'service' ? <IcUpBlue /> : <IcDownGrey />}
           {clickedDropdown === 'service' && (
@@ -70,13 +70,13 @@ const ServiceHistoryListItem = ({ idx, currentDropDown, setCurrentDropDown }: Se
           )}
         </S.DropDownBox>
       </S.SelectBox>
-      <S.SelectBox $height={idx}>
-        <S.DropDownBox
-          $isClicked={clickedDropdown === 'period'}
-          onClick={() => {
-            setCurrentDropDown(idx);
-            clickedDropdown === 'period' ? setClickedDropdown(null) : setClickedDropdown('period');
-          }}>
+      <S.SelectBox
+        $height={idx}
+        onClick={() => {
+          setCurrentDropDown(idx);
+          clickedDropdown === 'period' ? setClickedDropdown(null) : setClickedDropdown('period');
+        }}>
+        <S.DropDownBox $isClicked={clickedDropdown === 'period'}>
           <input type="button" value={serviceHistory.hairServiceRecords[idx].hairServiceTerm || '기간  선택'} />
           {clickedDropdown === 'period' ? <IcUpBlue /> : <IcDownGrey />}
           {clickedDropdown === 'period' && (

--- a/src/views/ApplicationPage/constants/message.ts
+++ b/src/views/ApplicationPage/constants/message.ts
@@ -18,6 +18,7 @@ export const INFO_MESSAGE = {
   ADD_HISTORY: '+ 눌러서 추가하기',
   SERVICE_SELECT_BOX: '시술 선택',
   PERIOD_SELECT_BOX: '기간 선택',
+  FILLED_FORM_TITLE: '시술과 기간을 모두 입력해주세요',
 
   PROFILE_TITLE: '지원 사진',
   PROFILE_SUBTITLE: '딱 맞는 스타일 제안을 위해,<br />반드시 본인 사진을 등록해주세요',


### PR DESCRIPTION
<!-- PR의 제목은 "[페이지명] 구현내용 " 으로, 연결되는 이슈 제목과 동일하게 가져가시면 됩니다! -->

![PR](https://github.com/TEAM-MODDY/moddy-web/assets/81505421/2d53d2e3-fcc8-4b65-835a-b118664382be)

## ▶️ Related Issue

- close #421 

<br />

## ✅ Done Task
- 시술 내역 경고 모달창 추가
- 드롭다운 박스 선택 영역 수정

<br />

## 🔎 PR Point

<!-- 리뷰어에게 나의 코드를 설명해주세요 -->
공통 컴포넌트로 만들어주었던 `ToastMessage` 컴포넌트를 활용해서 하나의 드롭다운이라도 선택되지 않았을 경우, 경고창이 뜰 수 있게 만들어주었습니다.

기존에 서버에 데이터를 넘겨줄 때 `null`값이 포함된 배열 (`['', '']`)은 빈 배열로 바꿔주는 과정이 필요해서 예외 처리를 만들어주는 함수를 사용했었는데요. 이번에 아예 선택된 값이 없을 경우, 다음 버튼이 활성화되지 않게 만들어줘서 데이터를 변환하는 과정을 없애주었습니다.
```tsx
//기존의 함수
  const exceptionNull = () => {
    if (
      serviceHistory.hairServiceRecords[0].hairService === '' ||
      serviceHistory.hairServiceRecords[0].hairServiceTerm === ''
    )
      setServiceHistory({ ...serviceHistory, hairServiceRecords: [] });
  };

//새롭게 만든 함수
  const isHistoryFilled = () => {
    const notEmpty = serviceHistory.hairServiceRecords.every((element) => {
      return element.hairService !== '' && element.hairServiceTerm !== '';
    });
    notEmpty ? setStep({ ...step, current: step.current + 1 }) : setToastOpen(true);
  };
```
빈 드롭다운 박스가 없을 경우 다음 `step`으로 넘어가고 아닐 경우는 토스트 창이 뜰 수 있도록 만들어주었습니다 !


추가로, 승희가 저번에 달아준 코리 반영해서 드롭다운 내부에서는 텍스트 바깥 영역을 클릭해도 드롭다운이 열리게끔 클릭 영역을 확장해주었습니당
<br />

## 📸 Screenshot
![moddy, 지출 없이 예쁜 머리 - Chrome 2024-03-11 07-00-08](https://github.com/TEAM-MODDY/moddy-web/assets/101045330/0078f572-1752-4326-a03e-19157d98bfb5)

<!-- 없으면 삭제 -->
