### PR TITLE
[MainPage] 로그인 이동 시 animation이 작동하여 상태바 색상이 어색하게 바뀌는 이슈 해결

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="ko">
 
 <head>
@@ -27,6 +27,7 @@
   <title>moddy, 지출 없이 예쁜 머리</title>
   <meta name="description" content="쉬운 헤어모델 연결플랫폼" />
   <meta name="keywords" content="헤어모델, moddy, Moddy, 모델" />
+  <meta id="status-bar" name="theme-color" content="#ffffff" />
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-BBHL939ELH"></script>
   <script>
     window.dataLayer = window.dataLayer || [];

--- a/src/styles/GlobalStyle.ts
+++ b/src/styles/GlobalStyle.ts
@@ -123,8 +123,6 @@ export const reset = css`
 
   body {
     line-height: 1;
-
-    transition: background-color 0.2s ease;
   }
 
   menu,

--- a/src/views/MainPage/components/GuestContents.tsx
+++ b/src/views/MainPage/components/GuestContents.tsx
@@ -15,9 +15,8 @@ const GuestContents = () => {
   const [isOpenDetail, setOpenDetail] = useState(0);
 
   useEffect(() => {
-    isOpenDetail > 0
-      ? (document.body.style.backgroundColor = '#FFFFFF')
-      : (document.body.style.backgroundColor = '#3287FF');
+    const metaElement = document.getElementById('status-bar') as HTMLMetaElement;
+    isOpenDetail > 0 ? (metaElement.content = '#FFFFFF') : (metaElement.content = '#3287FF');
   }, [isOpenDetail]);
 
   const DetailPage = ({ imgSrc }: DetailPageProps) => {

--- a/src/views/MainPage/hooks/useStatusBarColor.ts
+++ b/src/views/MainPage/hooks/useStatusBarColor.ts
@@ -1,58 +1,38 @@
 import { useEffect, useState } from 'react';
-import { useLocation } from 'react-router-dom';
 
 const useStatusBarColor = () => {
-  const location = useLocation();
   const [themeColor, setThemeColor] = useState<string>('#3287FF'); // 초기 상태바 색상 설정 (메인화면)
 
-  useEffect(() => {
-    const handleScroll = () => {
-      const colors = [
-        { offset: 0, color: '#3287FF' },
-        { offset: 60, color: '#337bFF' },
-        { offset: 80, color: '#236FFF' },
-        { offset: 140, color: '#4879FF' },
-        { offset: 200, color: '#7282FF' },
-        { offset: 210, color: '#FFFFFF' },
-        { offset: 217, color: '#FFFFFF' },
-      ];
+  const handleScroll = () => {
+    const colors = [
+      { offset: 0, color: '#3287FF' },
+      { offset: 60, color: '#337bFF' },
+      { offset: 80, color: '#236FFF' },
+      { offset: 140, color: '#4879FF' },
+      { offset: 200, color: '#7282FF' },
+      { offset: 210, color: '#FFFFFF' },
+      { offset: 217, color: '#FFFFFF' },
+    ];
 
-      const currentScrollY = window.scrollY;
-      let startColor: { offset: number; color: string } = { offset: 0, color: '#3287FF' };
-      let endColor: { offset: number; color: string } = { offset: 0, color: '#3287FF' };
+    const currentScrollY = window.scrollY;
+    let startColor: { offset: number; color: string } = { offset: 0, color: '#3287FF' };
+    let endColor: { offset: number; color: string } = { offset: 0, color: '#3287FF' };
 
-      // 현재 스크롤 위치에 따라 시작 색상과 끝 색상 설정
-      for (let i = 0; i < colors.length - 1; i++) {
-        if (currentScrollY >= colors[i].offset && currentScrollY < colors[i + 1].offset) {
-          startColor = colors[i];
-          endColor = colors[i + 1];
-          break;
-        }
+    // 현재 스크롤 위치에 따라 시작 색상과 끝 색상 설정
+    for (let i = 0; i < colors.length - 1; i++) {
+      if (currentScrollY >= colors[i].offset && currentScrollY < colors[i + 1].offset) {
+        startColor = colors[i];
+        endColor = colors[i + 1];
+        break;
       }
-
-      // 보간법을 사용하여 현재 스크롤 위치에 따른 상태바 색상 계산
-      const progress = (currentScrollY - startColor.offset) / (endColor.offset - startColor.offset);
-      const interpolatedColor = interpolateColor(startColor.color, endColor.color, progress);
-
-      setThemeColor(interpolatedColor);
-    };
-
-    if (location.pathname === '/') {
-      window.addEventListener('scroll', handleScroll);
     }
 
-    return () => {
-      window.removeEventListener('scroll', handleScroll);
-      const metaElement = document.getElementById('status-bar') as HTMLMetaElement;
-      if (metaElement) metaElement.content = '#FFFFFF';
-    };
-  }, [location.pathname]);
+    // 보간법을 사용하여 현재 스크롤 위치에 따른 상태바 색상 계산
+    const progress = (currentScrollY - startColor.offset) / (endColor.offset - startColor.offset);
+    const interpolatedColor = interpolateColor(startColor.color, endColor.color, progress);
 
-  useEffect(() => {
-    const metaElement = document.getElementById('status-bar') as HTMLMetaElement;
-    if (metaElement) metaElement.content = themeColor;
-    document.body.style.backgroundColor = themeColor;
-  }, [themeColor]);
+    setThemeColor(interpolatedColor);
+  };
 
   // 보간 함수: 두 색상 사이를 보간하여 중간 색상 계산
   const interpolateColor = (startColor: string, endColor: string, progress: number): string => {
@@ -77,6 +57,22 @@ const useStatusBarColor = () => {
   const rgbToHex = (r: number, g: number, b: number) => {
     return '#' + ((1 << 24) + (r << 16) + (g << 8) + b).toString(16).slice(1);
   };
+
+  useEffect(() => {
+    window.addEventListener('scroll', handleScroll);
+
+    return () => {
+      window.removeEventListener('scroll', handleScroll);
+      const metaElement = document.getElementById('status-bar') as HTMLMetaElement;
+      if (metaElement) metaElement.content = '#FFFFFF';
+    };
+  }, []);
+
+  useEffect(() => {
+    const metaElement = document.getElementById('status-bar') as HTMLMetaElement;
+    if (metaElement) metaElement.content = themeColor;
+    document.body.style.backgroundColor = themeColor;
+  }, [themeColor]);
 };
 
 export default useStatusBarColor;

--- a/src/views/MainPage/hooks/useStatusBarColor.ts
+++ b/src/views/MainPage/hooks/useStatusBarColor.ts
@@ -1,36 +1,82 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { useLocation } from 'react-router-dom';
 
 const useStatusBarColor = () => {
   const location = useLocation();
+  const [themeColor, setThemeColor] = useState<string>('#3287FF'); // 초기 상태바 색상 설정 (메인화면)
 
   useEffect(() => {
     const handleScroll = () => {
-      if (window.scrollY > 217) {
-        document.body.style.backgroundColor = '#ffffff';
-      } else {
-        if (window.scrollY > 200) {
-          document.body.style.backgroundColor = '#7282FF';
-        } else if (window.scrollY > 140) {
-          document.body.style.backgroundColor = '#4879FF';
-        } else if (window.scrollY > 80) {
-          document.body.style.backgroundColor = '#236FFF';
-        } else if (window.scrollY > 60) {
-          document.body.style.backgroundColor = '#337bff';
-        } else {
-          document.body.style.backgroundColor = '#3287FF';
+      const colors = [
+        { offset: 0, color: '#3287FF' },
+        { offset: 60, color: '#337bFF' },
+        { offset: 80, color: '#236FFF' },
+        { offset: 140, color: '#4879FF' },
+        { offset: 200, color: '#7282FF' },
+        { offset: 210, color: '#FFFFFF' },
+        { offset: 217, color: '#FFFFFF' },
+      ];
+
+      const currentScrollY = window.scrollY;
+      let startColor: { offset: number; color: string } = { offset: 0, color: '#3287FF' };
+      let endColor: { offset: number; color: string } = { offset: 0, color: '#3287FF' };
+
+      // 현재 스크롤 위치에 따라 시작 색상과 끝 색상 설정
+      for (let i = 0; i < colors.length - 1; i++) {
+        if (currentScrollY >= colors[i].offset && currentScrollY < colors[i + 1].offset) {
+          startColor = colors[i];
+          endColor = colors[i + 1];
+          break;
         }
       }
+
+      // 보간법을 사용하여 현재 스크롤 위치에 따른 상태바 색상 계산
+      const progress = (currentScrollY - startColor.offset) / (endColor.offset - startColor.offset);
+      const interpolatedColor = interpolateColor(startColor.color, endColor.color, progress);
+
+      setThemeColor(interpolatedColor);
     };
+
     if (location.pathname === '/') {
-      document.body.style.background = '#3287FF';
       window.addEventListener('scroll', handleScroll);
     }
+
     return () => {
       window.removeEventListener('scroll', handleScroll);
-      document.body.style.backgroundColor = '#ffffff';
+      const metaElement = document.getElementById('status-bar') as HTMLMetaElement;
+      if (metaElement) metaElement.content = '#FFFFFF';
     };
   }, [location.pathname]);
+
+  useEffect(() => {
+    const metaElement = document.getElementById('status-bar') as HTMLMetaElement;
+    if (metaElement) metaElement.content = themeColor;
+    document.body.style.backgroundColor = themeColor;
+  }, [themeColor]);
+
+  // 보간 함수: 두 색상 사이를 보간하여 중간 색상 계산
+  const interpolateColor = (startColor: string, endColor: string, progress: number): string => {
+    const start = hexToRgb(startColor);
+    const end = hexToRgb(endColor);
+    const r = Math.round(start.r + (end.r - start.r) * progress);
+    const g = Math.round(start.g + (end.g - start.g) * progress);
+    const b = Math.round(start.b + (end.b - start.b) * progress);
+    return rgbToHex(r, g, b);
+  };
+
+  // 16진수 색상을 RGB로 변환
+  const hexToRgb = (hex: string) => {
+    const bigint = parseInt(hex.slice(1), 16);
+    const r = (bigint >> 16) & 255;
+    const g = (bigint >> 8) & 255;
+    const b = bigint & 255;
+    return { r, g, b };
+  };
+
+  // RGB 색상을 16진수로 변환
+  const rgbToHex = (r: number, g: number, b: number) => {
+    return '#' + ((1 << 24) + (r << 16) + (g << 8) + b).toString(16).slice(1);
+  };
 };
 
 export default useStatusBarColor;


### PR DESCRIPTION
<!-- PR의 제목은 "[페이지명] 구현내용 " 으로, 연결되는 이슈 제목과 동일하게 가져가시면 됩니다! -->

![PR](https://github.com/TEAM-MODDY/moddy-web/assets/81505421/2d53d2e3-fcc8-4b65-835a-b118664382be)

## ▶️ Related Issue

- close #423

<br />

## 🚨 Problem
로그인 이동 시 animation이 작동하여 상태바 색상이 어색하게 바뀌는 이슈

처음에 `<meta name="theme-color" />`를 이용하여 구현하려하였으나 스크롤 시 색상전환이 부드럽지 못하여 css animation을 적용하기 위해서 body에 animation을 주고 스크롤 위치에 따라 색을 정해주는 방법으로 구현을 하였습니다,
하지만 이렇게 할 경우 다른 뷰로 이동시에도 animation이 작동하여 어색한 느낌을 주고 있었습니다.

https://github.com/TEAM-MODDY/moddy-web/assets/46593078/61b7f4a4-71bd-4a01-963e-907b2e3a69b4

<br />

## 🚑 Solution

theme-color에 알고리즘을 통해 animation처럼 구현할 방법을 찾아보았습니다.
키프레임 애니메이션의 원리는 보간(Interpolation)입니다
 이 보간법을 사용하면 시작점과 끝점 사이의 값을 부드럽게 전환하는 것이 가능해 질 수 있습니다

```ts
const interpolateColor = (startColor: string, endColor: string, progress: number): string => {
    const start = hexToRgb(startColor);
    const end = hexToRgb(endColor);
    const r = Math.round(start.r + (end.r - start.r) * progress);
    const g = Math.round(start.g + (end.g - start.g) * progress);
    const b = Math.round(start.b + (end.b - start.b) * progress);
    return rgbToHex(r, g, b);
  };
```

> 여기에 사용된 보간법은 선형 보간법으로, 시작 색상과 끝 색상을 기반으로 특정 진행도에 따라 중간 색상을 계산합니다.

> 먼저, hexToRgb 함수를 통해 시작 색상과 끝 색상을 각각 RGB 값으로 변환합니다. 그 다음, 주어진 진행도에 따라 시작 색상과 끝 색상 사이의
각 색상 성분(R, G, B)을 계산합니다. 이때 진행도가 0이면 시작 색상이, 1이면 끝 색상이 선택되고, 그 사이 값은 진행도에 따라 선형적으로 보간됩니다.

> 그런 다음, 계산된 RGB 값들을 다시 rgbToHex 함수를 통해 16진수 형태로 변환하여 반환합니다. 이렇게 하면 시작 색상과 끝 색상 사이를 주어진 진행도에 맞게 보간한 중간 색상을 구할 수 있습니다.

https://github.com/TEAM-MODDY/moddy-web/assets/46593078/f0cc6136-2150-4ed0-b14e-b4cfc68c41db



<br />

## 📸 Screenshot

이제 이동 시 깔끔하게 색상이 전환됩니다!

https://github.com/TEAM-MODDY/moddy-web/assets/46593078/435484e0-ad14-46c3-a787-811fb356b664




<!-- 없으면 삭제 -->
