### PR TITLE
[EditPage] 모델 정보 수정 뷰 기능 구현

### DIFF
--- a/src/views/EditInfoPage/components/ModelEditInfoSection.tsx
+++ b/src/views/EditInfoPage/components/ModelEditInfoSection.tsx
@@ -60,8 +60,7 @@ const ModelEditInfoSection = () => {
       {isSaveModalOpen && (
         <Modal
           title="프로필을 수정할까요?"
-          description="이전에 작성했던 내용은 사라
-          져요"
+          description="이전에 작성했던 내용은 사라져요"
           leftBtnText="취소"
           leftBtnFn={handleCloseSaveModal}
           rightBtnText="확인"

--- a/src/views/EditInfoPage/components/ModelEditInfoSection.tsx
+++ b/src/views/EditInfoPage/components/ModelEditInfoSection.tsx
@@ -1,69 +1,23 @@
-import { useEffect, useRef, useState } from 'react';
+import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { useRecoilValue } from 'recoil';
 import { styled } from 'styled-components';
 
-import { preferRegionState } from '@/recoil/atoms/signUpState';
-import { IcCloseSmBlue, IcDownGrey, IcInformation, IcUpBlue } from '@/views/@common/assets/icons';
+import ModelInfo from './ModelInfo';
+
 import Header from '@/views/@common/components/Header';
-import Input from '@/views/@common/components/Input';
 import Modal from '@/views/@common/components/Modal';
-import RegionItem from '@/views/@common/components/RegionItem';
-import TitleField from '@/views/@common/components/TitleField';
+import ToastMessage from '@/views/@common/components/ToastMessage';
 
 const ModelEditInfoSection = () => {
-  const regionList = [
-    { id: 0, name: '전체' },
-    { id: 1, name: '강남구' },
-    { id: 2, name: '서초구' },
-    { id: 3, name: '관악구' },
-    { id: 4, name: '종로구' },
-    { id: 5, name: '광진구' },
-    { id: 6, name: '송파구' },
-  ];
-  const isRegionList = useRecoilValue(preferRegionState);
-  const [isShowCategory, setIsShowCategory] = useState(false);
-  const categoryRef = useRef<HTMLDivElement>(null);
-  const selectorBoxRef = useRef<HTMLDivElement>(null);
   const [isSaveModalOpen, setSaveModalOpen] = useState(false);
   const [isBackModalOpen, setBackModalOpen] = useState(false);
+  const [isChanged, setIsChanged] = useState(false);
+  const [isToastOpen, setIsToastOpen] = useState(false);
+  const [toastMsg, setToastMsg] = useState('');
   const navigate = useNavigate();
-  const [isChanged] = useState(false);
 
-  const isRegionSelected = isRegionList.every((region) => !region);
-
-  useEffect(() => {
-    // 특정 영역 외 클릭 시 발생하는 이벤트
-    const handleFocus = (e: MouseEvent) => {
-      if (
-        categoryRef.current &&
-        !categoryRef.current.contains(e.target as Node) &&
-        selectorBoxRef.current &&
-        !selectorBoxRef.current.contains(e.target as Node)
-      ) {
-        setIsShowCategory(false);
-      }
-    };
-
-    document.addEventListener('mouseup', handleFocus);
-
-    return () => {
-      document.removeEventListener('mouseup', handleFocus);
-    };
-  }, [categoryRef]);
-
-  //오른쪽 저장클릭시 동작
-  const handleSaveBtn = () => {
-    if (isChanged) {
-      setSaveModalOpen(true);
-    } else {
-      navigate('/my-page');
-    }
-  };
-
-  const handleCloseSaveModal = () => {
-    setSaveModalOpen(false);
-  };
+  //이후 put으로 변경될 예정
+  const handleSaveInfo = () => {};
 
   //왼쪽 이전으로 버튼 클릭시 동작
   const handleBackBtn = () => {
@@ -78,21 +32,24 @@ const ModelEditInfoSection = () => {
     setBackModalOpen(false);
   };
 
-  //이후 put으로 변경될 예정
-  const handleSaveInfo = () => {
-    console.log('ㅇㅇ');
+  //오른쪽 저장클릭시 동작
+  const handleSaveBtn = () => {
+    if (toastMsg) {
+      setIsToastOpen(true);
+    } else if (isChanged) {
+      setSaveModalOpen(true);
+    } else {
+      navigate('/my-page');
+    }
   };
 
-  const handleShowCategory = () => {
-    setIsShowCategory((prev) => !prev);
-  };
-
-  const handleInputChange = (key: string, value: string) => {
-    console.log(key, value);
+  const handleCloseSaveModal = () => {
+    setSaveModalOpen(false);
   };
 
   return (
     <S.ModelEditInfoSectionLayout>
+      {isToastOpen && <ToastMessage text={toastMsg} setter={setIsToastOpen} />}
       <Header
         title="프로필 수정"
         isBackBtnExist={true}
@@ -103,7 +60,8 @@ const ModelEditInfoSection = () => {
       {isSaveModalOpen && (
         <Modal
           title="프로필을 수정할까요?"
-          description="이전에 작성했던 내용은 사라져요"
+          description="이전에 작성했던 내용은 사라
+          져요"
           leftBtnText="취소"
           leftBtnFn={handleCloseSaveModal}
           rightBtnText="확인"
@@ -122,71 +80,7 @@ const ModelEditInfoSection = () => {
           }}
         />
       )}
-
-      <S.ModelInfoSection>
-        <S.InputBox>
-          <TitleField text="이름" isEssential={true} />
-          <Input placeholderText="정보" onChangeFn={(value) => handleInputChange('name', value)} />
-          <S.HelperBox>
-            <IcInformation />
-            <S.HelperSpan>실명을 입력해주세요</S.HelperSpan>
-          </S.HelperBox>
-        </S.InputBox>
-        <S.InputBox>
-          <TitleField text="출생 연도" isEssential={true} />
-          <Input placeholderText="정보" onChangeFn={(value) => handleInputChange('birthYear', value)} />
-        </S.InputBox>
-        <S.InputBox>
-          <TitleField text="성별" isEssential={true} />
-          <S.GenderSelectBox>
-            <S.GenderRadio type="radio" />
-            <S.GenderLabel>여성</S.GenderLabel>
-            <S.GenderRadio type="radio" />
-            <S.GenderLabel>남성</S.GenderLabel>
-          </S.GenderSelectBox>
-        </S.InputBox>
-        <S.InputBox>
-          <TitleField text="전화번호" isEssential={true} />
-          <S.DisabledInputBox>정보</S.DisabledInputBox>
-        </S.InputBox>
-        <S.InputBox>
-          <TitleField text="시술희망 지역" isEssential={true} />
-          <S.SelectorBox
-            $isShowChecked={isShowCategory.toString()}
-            $isRegionSelected={isRegionSelected}
-            onClick={handleShowCategory}
-            ref={selectorBoxRef}>
-            {isRegionSelected
-              ? '희망 지역 선택 안내'
-              : isRegionList.map((region, index) =>
-                  region ? (
-                    <S.SelectedRegionBox key={index}>
-                      <S.RegionName>{regionList[index].name}</S.RegionName>
-                      <IcCloseSmBlue />
-                    </S.SelectedRegionBox>
-                  ) : null,
-                )}
-            {!isShowCategory ? <IcDownGrey /> : <IcUpBlue />}
-          </S.SelectorBox>
-          {!isShowCategory ? (
-            <S.HelperBox>
-              <IcInformation />
-              <S.HelperSpan>지금은 서울특별시에서만 운영하고 있어요.</S.HelperSpan>
-            </S.HelperBox>
-          ) : (
-            <S.CategoryBox ref={categoryRef}>
-              <S.InnerBox>
-                <S.CitySpan>서울특별시</S.CitySpan>
-                <S.RegionList>
-                  {regionList.map((region, index) => (
-                    <RegionItem key={index} region={region.name} index={region.id} regionList={regionList} />
-                  ))}
-                </S.RegionList>
-              </S.InnerBox>
-            </S.CategoryBox>
-          )}
-        </S.InputBox>
-      </S.ModelInfoSection>
+      <ModelInfo setIsChanged={setIsChanged} setToastMsg={setToastMsg} />
     </S.ModelEditInfoSectionLayout>
   );
 };
@@ -202,145 +96,6 @@ const S = {
   SaveBtn: styled.span`
     cursor: pointer;
     ${({ theme }) => theme.fonts.Body02};
-  `,
-  ModelInfoSection: styled.section`
-    display: flex;
-    flex-direction: column;
-    gap: 3.6rem;
-  `,
-  InputBox: styled.div`
-    display: flex;
-    flex-direction: column;
-    gap: 1.2rem;
-  `,
-  GenderSelectBox: styled.div`
-    display: flex;
-    gap: 1.6rem;
-  `,
-  GenderRadio: styled.input`
-    display: none;
-
-    &:checked + label {
-      border: 1.5px solid ${({ theme }) => theme.colors.moddy_blue};
-
-      box-shadow: ${({ theme }) => theme.effects.shadow2};
-
-      color: ${({ theme }) => theme.colors.moddy_bk};
-    }
-  `,
-  GenderLabel: styled.label`
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    align-items: center;
-    flex-grow: 1;
-
-    width: 16.4rem;
-    padding: 1.2rem 0;
-    border: 1.5px solid ${({ theme }) => theme.colors.moddy_gray20};
-    border-radius: 8px;
-
-    background: ${({ theme }) => theme.colors.moddy_wt};
-
-    color: ${({ theme }) => theme.colors.moddy_gray50};
-    ${({ theme }) => theme.fonts.Body01};
-  `,
-  DisabledInputBox: styled.div`
-    width: 100%;
-    height: 4.2rem;
-    padding: 1.2rem 1.5rem;
-    border: 1.5px solid ${({ theme }) => theme.colors.moddy_gray20};
-    border-radius: 8px;
-
-    background-color: ${({ theme }) => theme.colors.moddy_gray05};
-
-    color: ${({ theme }) => theme.colors.moddy_gray50};
-    ${({ theme }) => theme.fonts.Body02};
-  `,
-
-  SelectorBox: styled.div<{ $isShowChecked: string; $isRegionSelected: boolean }>`
-    display: flex;
-    gap: 1rem;
-    position: relative;
-
-    width: 100%;
-    padding: ${({ $isRegionSelected }) => ($isRegionSelected ? '1.2rem 1.6rem' : '0.4rem')};
-    border: 1.5px solid
-      ${({ theme, $isShowChecked }) =>
-        $isShowChecked === 'true' ? theme.colors.moddy_blue : theme.colors.moddy_gray20};
-    ${({ theme }) => theme.colors.moddy_gray20};
-
-    border-radius: 8px;
-    ${({ theme }) => theme.fonts.Body02};
-
-    color: ${({ theme }) => theme.colors.moddy_gray50};
-
-    & > svg {
-      position: absolute;
-      top: 1.1rem;
-      right: 1.3rem;
-    }
-  `,
-
-  SelectedRegionBox: styled.div`
-    display: flex;
-    gap: 0.4rem;
-    align-items: center;
-
-    width: fit-content;
-    padding: 0.7rem 1.2rem;
-    border: 1.5px solid ${({ theme }) => theme.colors.moddy_blue};
-    border-radius: 6px;
-
-    background-color: ${({ theme }) => theme.colors.moddy_blue4};
-  `,
-  RegionName: styled.span`
-    height: fit-content;
-
-    color: ${({ theme }) => theme.colors.moddy_blue};
-    ${({ theme }) => theme.fonts.Headline04};
-  `,
-
-  HelperBox: styled.div`
-    display: flex;
-    gap: 0.4rem;
-
-    margin-top: -0.4rem;
-  `,
-
-  HelperSpan: styled.span`
-    color: ${({ theme }) => theme.colors.moddy_blue2};
-    ${({ theme }) => theme.fonts.Body04};
-  `,
-
-  CategoryBox: styled.div`
-    display: flex;
-    flex-direction: column;
-    z-index: 1;
-
-    width: 100%;
-    height: 25.8rem;
-    margin-top: 0.4rem;
-    padding: 1.2rem;
-    border-radius: 8px;
-
-    background: ${({ theme }) => theme.colors.moddy_wt};
-    box-shadow: ${({ theme }) => theme.effects.shadow4};
-  `,
-  InnerBox: styled.div`
-    width: 100%;
-
-    ${({ theme }) => theme.commons.scrollbar};
-  `,
-
-  CitySpan: styled.span`
-    color: ${({ theme }) => theme.colors.moddy_blue2};
-    ${({ theme }) => theme.fonts.Body03};
-  `,
-
-  RegionList: styled.ul`
-    margin-top: 0.4rem;
-    padding: 0.6rem 2rem;
   `,
 };
 

--- a/src/views/EditInfoPage/components/ModelInfo.tsx
+++ b/src/views/EditInfoPage/components/ModelInfo.tsx
@@ -69,6 +69,22 @@ const ModelInfo = ({ setIsChanged, setToastMsg }: ModelInfoProps) => {
   ];
 
   useEffect(() => {
+    const checkVerified = () => {
+      if (!REGEX.NAME.test(info.name)) {
+        setToastMsg(MODEL_TOAST_MESSAGE.NAME);
+      } else if (!REGEX.BIRTH_YEAR.test(info.year)) {
+        setToastMsg(MODEL_TOAST_MESSAGE.BIRTH_YEAR);
+      } else if (!info.preferRegions.length) {
+        setToastMsg(MODEL_TOAST_MESSAGE.REGION);
+      } else {
+        setToastMsg('');
+      }
+    };
+
+    checkVerified();
+  }, [info]);
+
+  useEffect(() => {
     // 특정 영역 외 클릭 시 발생하는 이벤트
     const handleFocus = (e: MouseEvent) => {
       if (
@@ -93,20 +109,7 @@ const ModelInfo = ({ setIsChanged, setToastMsg }: ModelInfoProps) => {
       ...prevInfo,
       [key]: newValue,
     }));
-    checkVerified(key, newValue);
     setIsChanged(true);
-  };
-
-  const checkVerified = (key: string, value: string) => {
-    if (!REGEX.NAME.test(info.name) || (key === 'name' && !REGEX.NAME.test(value))) {
-      setToastMsg(MODEL_TOAST_MESSAGE.NAME);
-    } else if (!REGEX.NAME.test(info.year) || (key === 'birthYear' && !REGEX.BIRTH_YEAR.test(value))) {
-      setToastMsg(MODEL_TOAST_MESSAGE.BIRTH_YEAR);
-    } else if (!info.preferRegions.length) {
-      setToastMsg(MODEL_TOAST_MESSAGE.REGION);
-    } else {
-      setToastMsg('');
-    }
   };
 
   const deleteRegion = (event: React.MouseEvent<HTMLButtonElement, MouseEvent>, region: string) => {
@@ -114,6 +117,7 @@ const ModelInfo = ({ setIsChanged, setToastMsg }: ModelInfoProps) => {
       ...prevInfo,
       preferRegions: prevInfo.preferRegions.filter((r) => r !== region),
     }));
+    setIsChanged(true);
     event.stopPropagation();
   };
 
@@ -141,7 +145,7 @@ const ModelInfo = ({ setIsChanged, setToastMsg }: ModelInfoProps) => {
         <Input
           placeholderText={PLACE_HOLDER_MESSAGE.INPUT_BIRTH_YEAR}
           initialValue={info.year}
-          onChangeFn={(value) => handleInputChange('birthYear', value)}
+          onChangeFn={(value) => handleInputChange('year', value)}
           regex={REGEX.BIRTH_YEAR}
           maxLength={BIRTH_YEAR_LENGTH}
         />
@@ -201,7 +205,13 @@ const ModelInfo = ({ setIsChanged, setToastMsg }: ModelInfoProps) => {
               <S.CitySpan>서울특별시</S.CitySpan>
               <S.RegionList>
                 {regionList.map((region) => (
-                  <RegionList key={region.name} currentRegions={info.preferRegions} region={region} setInfo={setInfo} />
+                  <RegionList
+                    key={region.name}
+                    currentRegions={info.preferRegions}
+                    region={region}
+                    setInfo={setInfo}
+                    setIsChanged={setIsChanged}
+                  />
                 ))}
               </S.RegionList>
             </S.InnerBox>

--- a/src/views/EditInfoPage/components/ModelInfo.tsx
+++ b/src/views/EditInfoPage/components/ModelInfo.tsx
@@ -93,14 +93,14 @@ const ModelInfo = ({ setIsChanged, setToastMsg }: ModelInfoProps) => {
       ...prevInfo,
       [key]: newValue,
     }));
-    checkVerified();
+    checkVerified(key, newValue);
     setIsChanged(true);
   };
 
-  const checkVerified = () => {
-    if (!REGEX.NAME.test(info.name)) {
+  const checkVerified = (key: string, value: string) => {
+    if (!REGEX.NAME.test(info.name) || (key === 'name' && !REGEX.NAME.test(value))) {
       setToastMsg(MODEL_TOAST_MESSAGE.NAME);
-    } else if (!REGEX.BIRTH_YEAR.test(info.year)) {
+    } else if (!REGEX.NAME.test(info.year) || (key === 'birthYear' && !REGEX.BIRTH_YEAR.test(value))) {
       setToastMsg(MODEL_TOAST_MESSAGE.BIRTH_YEAR);
     } else if (!info.preferRegions.length) {
       setToastMsg(MODEL_TOAST_MESSAGE.REGION);

--- a/src/views/EditInfoPage/components/ModelInfo.tsx
+++ b/src/views/EditInfoPage/components/ModelInfo.tsx
@@ -87,8 +87,8 @@ const ModelInfo = ({ setIsChanged, setToastMsg }: ModelInfoProps) => {
     };
   }, [categoryRef]);
 
-  const handleInputChange = (key: string, value: string | React.MouseEvent<HTMLLabelElement, MouseEvent>) => {
-    const newValue = typeof value === 'string' ? value : value.currentTarget.innerText;
+  const handleInputChange = (key: string, value: string | React.ChangeEvent<HTMLInputElement>) => {
+    const newValue = typeof value === 'string' ? value : value.target.id;
     setInfo((prevInfo) => ({
       ...prevInfo,
       [key]: newValue,
@@ -107,6 +107,14 @@ const ModelInfo = ({ setIsChanged, setToastMsg }: ModelInfoProps) => {
     } else {
       setToastMsg('');
     }
+  };
+
+  const deleteRegion = (event: React.MouseEvent<HTMLButtonElement, MouseEvent>, region: string) => {
+    setInfo((prevInfo) => ({
+      ...prevInfo,
+      preferRegions: prevInfo.preferRegions.filter((r) => r !== region),
+    }));
+    event.stopPropagation();
   };
 
   const handleShowCategory = () => {
@@ -141,14 +149,22 @@ const ModelInfo = ({ setIsChanged, setToastMsg }: ModelInfoProps) => {
       <S.InputBox>
         <TitleField text="성별" isEssential={true} />
         <S.GenderSelectBox>
-          <S.GenderRadio type="radio" id="FEMALE" name="gender-type" checked={info.gender === '여성'} />
-          <S.GenderLabel htmlFor="FEMALE" onClick={(value) => handleInputChange('gender', value)}>
-            여성
-          </S.GenderLabel>
-          <S.GenderRadio type="radio" id="MALE" name="gender-type" checked={info.gender === '남성'} />
-          <S.GenderLabel htmlFor="MALE" onClick={(value) => handleInputChange('gender', value)}>
-            남성
-          </S.GenderLabel>
+          <S.GenderRadio
+            type="radio"
+            id="여성"
+            name="gender-type"
+            checked={info.gender === '여성'}
+            onChange={(value) => handleInputChange('gender', value)}
+          />
+          <S.GenderLabel htmlFor="여성">여성</S.GenderLabel>
+          <S.GenderRadio
+            type="radio"
+            id="남성"
+            name="gender-type"
+            checked={info.gender === '남성'}
+            onChange={(value) => handleInputChange('gender', value)}
+          />
+          <S.GenderLabel htmlFor="남성">남성</S.GenderLabel>
         </S.GenderSelectBox>
       </S.InputBox>
       <S.InputBox>
@@ -166,7 +182,9 @@ const ModelInfo = ({ setIsChanged, setToastMsg }: ModelInfoProps) => {
             ? info.preferRegions.map((region) => (
                 <S.SelectedRegionBox key={region}>
                   <S.RegionName>{region}</S.RegionName>
-                  <IcCloseSmBlue />
+                  <button type="button" onClick={(event) => deleteRegion(event, region)}>
+                    <IcCloseSmBlue />
+                  </button>
                 </S.SelectedRegionBox>
               ))
             : PLACE_HOLDER_MESSAGE.SELECT_PREFER_REGION}

--- a/src/views/EditInfoPage/components/ModelInfo.tsx
+++ b/src/views/EditInfoPage/components/ModelInfo.tsx
@@ -1,0 +1,312 @@
+import { useEffect, useRef, useState } from 'react';
+import { styled } from 'styled-components';
+
+import { MODEL_TOAST_MESSAGE } from '../constants/message';
+
+import { IcCloseSmBlue, IcDownGrey, IcInformation, IcUpBlue } from '@/views/@common/assets/icons';
+import Input from '@/views/@common/components/Input';
+import RegionItem from '@/views/@common/components/RegionItem';
+import TitleField from '@/views/@common/components/TitleField';
+import { REGEX } from '@/views/@common/utils/regex';
+import { BIRTH_YEAR_LENGTH, NAME_MAX_LENGTH } from '@/views/SignUpPage/constants/constants';
+import { PLACE_HOLDER_MESSAGE } from '@/views/SignUpPage/constants/message';
+
+interface ModelInfoProps {
+  setIsChanged: React.Dispatch<React.SetStateAction<boolean>>;
+  setToastMsg: React.Dispatch<React.SetStateAction<string>>;
+}
+
+const ModelInfo = ({ setIsChanged, setToastMsg }: ModelInfoProps) => {
+  const [isShowCategory, setIsShowCategory] = useState(false);
+  const categoryRef = useRef<HTMLDivElement>(null);
+  const selectorBoxRef = useRef<HTMLDivElement>(null);
+
+  const [info, setInfo] = useState({
+    name: '안현주',
+    year: '2000',
+    gender: '여성',
+    phoneNumber: '010-1234-5678',
+    preferRegions: ['강남구', '도봉구'],
+  });
+
+  //get api로 리스트 받아올 예정
+  const regionList = [
+    { id: 0, name: '전체' },
+    { id: 1, name: '강남구' },
+    { id: 2, name: '서초구' },
+    { id: 3, name: '관악구' },
+    { id: 4, name: '종로구' },
+    { id: 5, name: '광진구' },
+    { id: 6, name: '송파구' },
+  ];
+
+  useEffect(() => {
+    // 특정 영역 외 클릭 시 발생하는 이벤트
+    const handleFocus = (e: MouseEvent) => {
+      if (
+        categoryRef.current &&
+        !categoryRef.current.contains(e.target as Node) &&
+        selectorBoxRef.current &&
+        !selectorBoxRef.current.contains(e.target as Node)
+      ) {
+        setIsShowCategory(false);
+      }
+    };
+
+    document.addEventListener('mouseup', handleFocus);
+    return () => {
+      document.removeEventListener('mouseup', handleFocus);
+    };
+  }, [categoryRef]);
+
+  const handleInputChange = (key: string, value: string | React.MouseEvent<HTMLLabelElement, MouseEvent>) => {
+    const newValue = typeof value === 'string' ? value : value.currentTarget.innerText;
+    console.log(newValue);
+    setInfo((prevInfo) => ({
+      ...prevInfo,
+      [key]: newValue,
+    }));
+    checkVerified();
+    setIsChanged(true);
+  };
+
+  const checkVerified = () => {
+    if (!REGEX.NAME.test(info.name)) {
+      setToastMsg(MODEL_TOAST_MESSAGE.NAME);
+    } else if (!REGEX.BIRTH_YEAR.test(info.year)) {
+      setToastMsg(MODEL_TOAST_MESSAGE.BIRTH_YEAR);
+    } else if (!info.preferRegions.length) {
+      setToastMsg(MODEL_TOAST_MESSAGE.REGION);
+    } else {
+      setToastMsg('');
+    }
+  };
+
+  const handleShowCategory = () => {
+    setIsShowCategory((prev) => !prev);
+  };
+
+  return (
+    <S.ModelInfoSectionLayout>
+      <S.InputBox>
+        <TitleField text="이름" isEssential={true} />
+        <Input
+          placeholderText={PLACE_HOLDER_MESSAGE.INPUT_NAME}
+          initialValue={info.name}
+          onChangeFn={(value) => handleInputChange('name', value)}
+          maxLength={NAME_MAX_LENGTH}
+        />
+        <S.HelperBox>
+          <IcInformation />
+          <S.HelperSpan>실명을 입력해주세요</S.HelperSpan>
+        </S.HelperBox>
+      </S.InputBox>
+      <S.InputBox>
+        <TitleField text="출생 연도" isEssential={true} />
+        <Input
+          placeholderText={PLACE_HOLDER_MESSAGE.INPUT_BIRTH_YEAR}
+          initialValue={info.year}
+          onChangeFn={(value) => handleInputChange('birthYear', value)}
+          regex={REGEX.BIRTH_YEAR}
+          maxLength={BIRTH_YEAR_LENGTH}
+        />
+      </S.InputBox>
+      <S.InputBox>
+        <TitleField text="성별" isEssential={true} />
+        <S.GenderSelectBox>
+          <S.GenderRadio type="radio" id="FEMALE" name="gender-type" checked={info.gender === '여성'} />
+          <S.GenderLabel htmlFor="FEMALE" onClick={(value) => handleInputChange('gender', value)}>
+            여성
+          </S.GenderLabel>
+          <S.GenderRadio type="radio" id="MALE" name="gender-type" checked={info.gender === '남성'} />
+          <S.GenderLabel htmlFor="MALE" onClick={(value) => handleInputChange('gender', value)}>
+            남성
+          </S.GenderLabel>
+        </S.GenderSelectBox>
+      </S.InputBox>
+      <S.InputBox>
+        <TitleField text="전화번호" isEssential={true} />
+        <S.DisabledInputBox>{info.phoneNumber}</S.DisabledInputBox>
+      </S.InputBox>
+      <S.InputBox>
+        <TitleField text="시술희망 지역" isEssential={true} />
+        <S.SelectorBox
+          $isShowChecked={isShowCategory.toString()}
+          $isRegionSelected={info.preferRegions.length}
+          onClick={handleShowCategory}
+          ref={selectorBoxRef}>
+          {info.preferRegions.length
+            ? PLACE_HOLDER_MESSAGE.SELECT_PREFER_REGION
+            : info.preferRegions.map((region) => (
+                <S.SelectedRegionBox key={region}>
+                  <S.RegionName>{region}</S.RegionName>
+                  <IcCloseSmBlue />
+                </S.SelectedRegionBox>
+              ))}
+          {!isShowCategory ? <IcDownGrey /> : <IcUpBlue />}
+        </S.SelectorBox>
+        {!isShowCategory ? (
+          <S.HelperBox>
+            <IcInformation />
+            <S.HelperSpan>지금은 서울특별시에서만 운영하고 있어요.</S.HelperSpan>
+          </S.HelperBox>
+        ) : (
+          <S.CategoryBox ref={categoryRef}>
+            <S.InnerBox>
+              <S.CitySpan>서울특별시</S.CitySpan>
+              <S.RegionList>
+                {regionList.map((region, index) => (
+                  <RegionItem key={index} region={region.name} index={region.id} regionList={regionList} />
+                ))}
+              </S.RegionList>
+            </S.InnerBox>
+          </S.CategoryBox>
+        )}
+      </S.InputBox>
+    </S.ModelInfoSectionLayout>
+  );
+};
+
+const S = {
+  ModelInfoSectionLayout: styled.section`
+    display: flex;
+    flex-direction: column;
+    gap: 3.6rem;
+  `,
+  InputBox: styled.div`
+    display: flex;
+    flex-direction: column;
+    gap: 1.2rem;
+  `,
+  GenderSelectBox: styled.div`
+    display: flex;
+    gap: 1.6rem;
+  `,
+  GenderRadio: styled.input`
+    display: none;
+
+    &:checked + label {
+      border: 1.5px solid ${({ theme }) => theme.colors.moddy_blue};
+
+      box-shadow: ${({ theme }) => theme.effects.shadow2};
+
+      color: ${({ theme }) => theme.colors.moddy_bk};
+    }
+  `,
+  GenderLabel: styled.label`
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    flex-grow: 1;
+
+    width: 16.4rem;
+    padding: 1.2rem 0;
+    border: 1.5px solid ${({ theme }) => theme.colors.moddy_gray20};
+    border-radius: 8px;
+
+    background: ${({ theme }) => theme.colors.moddy_wt};
+
+    color: ${({ theme }) => theme.colors.moddy_gray50};
+    ${({ theme }) => theme.fonts.Body01};
+  `,
+  DisabledInputBox: styled.div`
+    width: 100%;
+    height: 4.2rem;
+    padding: 1.2rem 1.5rem;
+    border: 1.5px solid ${({ theme }) => theme.colors.moddy_gray20};
+    border-radius: 8px;
+
+    background-color: ${({ theme }) => theme.colors.moddy_gray05};
+
+    color: ${({ theme }) => theme.colors.moddy_gray50};
+    ${({ theme }) => theme.fonts.Body02};
+  `,
+
+  SelectorBox: styled.div<{ $isShowChecked: string; $isRegionSelected: number }>`
+    display: flex;
+    gap: 1rem;
+    position: relative;
+
+    width: 100%;
+    padding: ${({ $isRegionSelected }) => ($isRegionSelected ? '1.2rem 1.6rem' : '0.4rem')};
+    border: 1.5px solid
+      ${({ theme, $isShowChecked }) =>
+        $isShowChecked === 'true' ? theme.colors.moddy_blue : theme.colors.moddy_gray20};
+    ${({ theme }) => theme.colors.moddy_gray20};
+
+    border-radius: 8px;
+    ${({ theme }) => theme.fonts.Body02};
+
+    color: ${({ theme }) => theme.colors.moddy_gray50};
+
+    & > svg {
+      position: absolute;
+      top: 1.1rem;
+      right: 1.3rem;
+    }
+  `,
+
+  SelectedRegionBox: styled.div`
+    display: flex;
+    gap: 0.4rem;
+    align-items: center;
+
+    width: fit-content;
+    padding: 0.7rem 1.2rem;
+    border: 1.5px solid ${({ theme }) => theme.colors.moddy_blue};
+    border-radius: 6px;
+
+    background-color: ${({ theme }) => theme.colors.moddy_blue4};
+  `,
+  RegionName: styled.span`
+    height: fit-content;
+
+    color: ${({ theme }) => theme.colors.moddy_blue};
+    ${({ theme }) => theme.fonts.Headline04};
+  `,
+
+  HelperBox: styled.div`
+    display: flex;
+    gap: 0.4rem;
+
+    margin-top: -0.4rem;
+  `,
+
+  HelperSpan: styled.span`
+    color: ${({ theme }) => theme.colors.moddy_blue2};
+    ${({ theme }) => theme.fonts.Body04};
+  `,
+
+  CategoryBox: styled.div`
+    display: flex;
+    flex-direction: column;
+    z-index: 1;
+
+    width: 100%;
+    height: 25.8rem;
+    margin-top: 0.4rem;
+    padding: 1.2rem;
+    border-radius: 8px;
+
+    background: ${({ theme }) => theme.colors.moddy_wt};
+    box-shadow: ${({ theme }) => theme.effects.shadow4};
+  `,
+  InnerBox: styled.div`
+    width: 100%;
+
+    ${({ theme }) => theme.commons.scrollbar};
+  `,
+
+  CitySpan: styled.span`
+    color: ${({ theme }) => theme.colors.moddy_blue2};
+    ${({ theme }) => theme.fonts.Body03};
+  `,
+
+  RegionList: styled.ul`
+    margin-top: 0.4rem;
+    padding: 0.6rem 2rem;
+  `,
+};
+
+export default ModelInfo;

--- a/src/views/EditInfoPage/components/ModelInfo.tsx
+++ b/src/views/EditInfoPage/components/ModelInfo.tsx
@@ -3,9 +3,10 @@ import { styled } from 'styled-components';
 
 import { MODEL_TOAST_MESSAGE } from '../constants/message';
 
+import RegionList from './RegionList';
+
 import { IcCloseSmBlue, IcDownGrey, IcInformation, IcUpBlue } from '@/views/@common/assets/icons';
 import Input from '@/views/@common/components/Input';
-import RegionItem from '@/views/@common/components/RegionItem';
 import TitleField from '@/views/@common/components/TitleField';
 import { REGEX } from '@/views/@common/utils/regex';
 import { BIRTH_YEAR_LENGTH, NAME_MAX_LENGTH } from '@/views/SignUpPage/constants/constants';
@@ -16,12 +17,20 @@ interface ModelInfoProps {
   setToastMsg: React.Dispatch<React.SetStateAction<string>>;
 }
 
+export interface UserInfo {
+  name: string;
+  year: string;
+  gender: string;
+  phoneNumber: string;
+  preferRegions: string[];
+}
+
 const ModelInfo = ({ setIsChanged, setToastMsg }: ModelInfoProps) => {
   const [isShowCategory, setIsShowCategory] = useState(false);
   const categoryRef = useRef<HTMLDivElement>(null);
   const selectorBoxRef = useRef<HTMLDivElement>(null);
 
-  const [info, setInfo] = useState({
+  const [info, setInfo] = useState<UserInfo>({
     name: '안현주',
     year: '2000',
     gender: '여성',
@@ -32,12 +41,31 @@ const ModelInfo = ({ setIsChanged, setToastMsg }: ModelInfoProps) => {
   //get api로 리스트 받아올 예정
   const regionList = [
     { id: 0, name: '전체' },
-    { id: 1, name: '강남구' },
-    { id: 2, name: '서초구' },
-    { id: 3, name: '관악구' },
-    { id: 4, name: '종로구' },
-    { id: 5, name: '광진구' },
-    { id: 6, name: '송파구' },
+    { id: 1, name: '관악구' },
+    { id: 2, name: '동작구' },
+    { id: 3, name: '강남구' },
+    { id: 4, name: '강동구' },
+    { id: 5, name: '강북구' },
+    { id: 6, name: '강서구' },
+    { id: 7, name: '광진구' },
+    { id: 8, name: '구로구' },
+    { id: 9, name: '금천구' },
+    { id: 10, name: '노원구' },
+    { id: 11, name: '도봉구' },
+    { id: 12, name: '동대문구' },
+    { id: 13, name: '마포구' },
+    { id: 14, name: '서대문구' },
+    { id: 15, name: '서초구' },
+    { id: 16, name: '성동구' },
+    { id: 17, name: '성북구' },
+    { id: 18, name: '송파구' },
+    { id: 19, name: '양천구' },
+    { id: 20, name: '영등포구' },
+    { id: 21, name: '용산구' },
+    { id: 22, name: '은평구' },
+    { id: 23, name: '종로구' },
+    { id: 24, name: '중구' },
+    { id: 25, name: '중랑구' },
   ];
 
   useEffect(() => {
@@ -61,7 +89,6 @@ const ModelInfo = ({ setIsChanged, setToastMsg }: ModelInfoProps) => {
 
   const handleInputChange = (key: string, value: string | React.MouseEvent<HTMLLabelElement, MouseEvent>) => {
     const newValue = typeof value === 'string' ? value : value.currentTarget.innerText;
-    console.log(newValue);
     setInfo((prevInfo) => ({
       ...prevInfo,
       [key]: newValue,
@@ -136,13 +163,13 @@ const ModelInfo = ({ setIsChanged, setToastMsg }: ModelInfoProps) => {
           onClick={handleShowCategory}
           ref={selectorBoxRef}>
           {info.preferRegions.length
-            ? PLACE_HOLDER_MESSAGE.SELECT_PREFER_REGION
-            : info.preferRegions.map((region) => (
+            ? info.preferRegions.map((region) => (
                 <S.SelectedRegionBox key={region}>
                   <S.RegionName>{region}</S.RegionName>
                   <IcCloseSmBlue />
                 </S.SelectedRegionBox>
-              ))}
+              ))
+            : PLACE_HOLDER_MESSAGE.SELECT_PREFER_REGION}
           {!isShowCategory ? <IcDownGrey /> : <IcUpBlue />}
         </S.SelectorBox>
         {!isShowCategory ? (
@@ -155,8 +182,8 @@ const ModelInfo = ({ setIsChanged, setToastMsg }: ModelInfoProps) => {
             <S.InnerBox>
               <S.CitySpan>서울특별시</S.CitySpan>
               <S.RegionList>
-                {regionList.map((region, index) => (
-                  <RegionItem key={index} region={region.name} index={region.id} regionList={regionList} />
+                {regionList.map((region) => (
+                  <RegionList key={region.name} currentRegions={info.preferRegions} region={region} setInfo={setInfo} />
                 ))}
               </S.RegionList>
             </S.InnerBox>
@@ -229,7 +256,7 @@ const S = {
     position: relative;
 
     width: 100%;
-    padding: ${({ $isRegionSelected }) => ($isRegionSelected ? '1.2rem 1.6rem' : '0.4rem')};
+    padding: ${({ $isRegionSelected }) => ($isRegionSelected ? '0.4rem' : '1.2rem 1.6rem')};
     border: 1.5px solid
       ${({ theme, $isShowChecked }) =>
         $isShowChecked === 'true' ? theme.colors.moddy_blue : theme.colors.moddy_gray20};

--- a/src/views/EditInfoPage/components/RegionList.tsx
+++ b/src/views/EditInfoPage/components/RegionList.tsx
@@ -1,0 +1,104 @@
+import { useEffect, useState } from 'react';
+import { styled } from 'styled-components';
+
+import { UserInfo } from './ModelInfo';
+
+import { IcCheckboxBlue, IcCheckboxGrey } from '@/views/@common/assets/icons';
+
+interface RegionItemProps {
+  currentRegions: string[];
+  region: {
+    id: number;
+    name: string;
+  };
+  setInfo: React.Dispatch<React.SetStateAction<UserInfo>>;
+}
+
+const RegionList = ({ currentRegions, region, setInfo }: RegionItemProps) => {
+  const SELECT_ALL = 0;
+  const [isActivated, setIsActivated] = useState(false);
+
+  useEffect(() => {
+    setIsActivated(currentRegions.includes(region.name));
+  }, [currentRegions]);
+
+  const 개별선택_또는_개별해제 = () => {
+    if (isActivated) {
+      const indexToRemove = currentRegions.indexOf(region.name);
+      currentRegions.splice(indexToRemove, 1);
+
+      setInfo((prevInfo) => ({
+        ...prevInfo,
+        preferRegions: [...currentRegions],
+      }));
+    } else {
+      setInfo((prevInfo) => ({
+        ...prevInfo,
+        preferRegions: [...currentRegions, region.name],
+      }));
+    }
+    setIsActivated((prev) => !prev);
+  };
+
+  const 전체선택_또는_전체해제 = () => {
+    //전체가 이미 선택돼있다면 전체 취소하기 - 선택돼있지 않다면 전체 선택하고 나머지 다 취소
+    if (isActivated) {
+      const newList: string[] = [];
+      setInfo((prevInfo) => ({
+        ...prevInfo,
+        preferRegions: newList,
+      }));
+    } else {
+      const newList = [region.name];
+      setInfo((prevInfo) => ({
+        ...prevInfo,
+        preferRegions: newList,
+      }));
+    }
+    setIsActivated((prev) => !prev);
+  };
+
+  const handleCheck = () => {
+    // 전체선택을 누르면
+    if (region.id === SELECT_ALL) {
+      전체선택_또는_전체해제();
+    } else {
+      //체크된게 3이상이면
+      if (currentRegions.length >= 3) {
+        //기존 체크된거 취소만 가능
+        if (isActivated) {
+          개별선택_또는_개별해제();
+        }
+      }
+      //아니라면 체크하기/체크풀기 가능
+      else {
+        개별선택_또는_개별해제();
+      }
+    }
+  };
+
+  return (
+    <S.CategoryItem>
+      <button type="button" onClick={handleCheck}>
+        {isActivated ? <IcCheckboxBlue /> : <IcCheckboxGrey />}
+      </button>
+      <S.RegionSpan $isChecked={true.toString()}>{region.name}</S.RegionSpan>
+    </S.CategoryItem>
+  );
+};
+
+const S = {
+  CategoryItem: styled.li`
+    display: flex;
+    gap: 0.8rem;
+    align-items: center;
+
+    padding: 0.6rem 0;
+  `,
+  RegionSpan: styled.span<{ $isChecked: string }>`
+    color: ${({ theme, $isChecked }) => ($isChecked === 'true' ? theme.colors.moddy_bk : theme.colors.moddy_gray50)};
+    ${({ theme }) => theme.fonts.Headline04};
+  `,
+};
+
+export default RegionList;

--- a/src/views/EditInfoPage/components/RegionList.tsx
+++ b/src/views/EditInfoPage/components/RegionList.tsx
@@ -12,9 +12,10 @@ interface RegionItemProps {
     name: string;
   };
   setInfo: React.Dispatch<React.SetStateAction<UserInfo>>;
+  setIsChanged: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
-const RegionList = ({ currentRegions, region, setInfo }: RegionItemProps) => {
+const RegionList = ({ currentRegions, region, setInfo, setIsChanged }: RegionItemProps) => {
   const SELECT_ALL = 0;
   const [isActivated, setIsActivated] = useState(false);
 
@@ -59,6 +60,8 @@ const RegionList = ({ currentRegions, region, setInfo }: RegionItemProps) => {
   };
 
   const handleCheck = () => {
+    setIsChanged(true);
+
     // 전체선택을 누르면
     if (region.id === SELECT_ALL) {
       전체선택_또는_전체해제();
@@ -78,17 +81,15 @@ const RegionList = ({ currentRegions, region, setInfo }: RegionItemProps) => {
   };
 
   return (
-    <S.CategoryItem>
-      <button type="button" onClick={handleCheck}>
-        {isActivated ? <IcCheckboxBlue /> : <IcCheckboxGrey />}
-      </button>
+    <S.RegionButton type="button" onClick={handleCheck}>
+      {isActivated ? <IcCheckboxBlue /> : <IcCheckboxGrey />}
       <S.RegionSpan $isChecked={true.toString()}>{region.name}</S.RegionSpan>
-    </S.CategoryItem>
+    </S.RegionButton>
   );
 };
 
 const S = {
-  CategoryItem: styled.li`
+  RegionButton: styled.button`
     display: flex;
     gap: 0.8rem;
     align-items: center;
@@ -96,6 +97,9 @@ const S = {
     padding: 0.6rem 0;
   `,
   RegionSpan: styled.span<{ $isChecked: string }>`
+    display: flex;
+    flex: 1;
+
     color: ${({ theme, $isChecked }) => ($isChecked === 'true' ? theme.colors.moddy_bk : theme.colors.moddy_gray50)};
     ${({ theme }) => theme.fonts.Headline04};
   `,

--- a/src/views/EditInfoPage/constants/message.ts
+++ b/src/views/EditInfoPage/constants/message.ts
@@ -12,3 +12,9 @@ export const TOAST_MESSAGE: { [key: string]: string } = {
   portfolio: '포트폴리오 링크를 정확히 입력해주세요.',
   openChat: '오픈채팅방 링크를 정확히 입력해주세요.',
 };
+
+export const MODEL_TOAST_MESSAGE = {
+  NAME: '이름을 1-5자로 입력해주세요.',
+  BIRTH_YEAR: '출생 연도를 정확히 입력해주세요.',
+  REGION: '시술희망 지역을 1곳 이상 선택해주세요.',
+};

--- a/src/views/SignUpPage/components/3_선호지역선택/PreferRegion.tsx
+++ b/src/views/SignUpPage/components/3_선호지역선택/PreferRegion.tsx
@@ -5,12 +5,13 @@ import { styled } from 'styled-components';
 import { IcDownGrey, IcInformation, IcUpBlue, IcCloseSmBlue } from '../../../@common/assets/icons';
 import Button from '../../../@common/components/Button';
 import ProgressBar from '../../../@common/components/ProgressBar';
-import RegionItem from '../../../@common/components/RegionItem';
 import { PREFER_REGION_MIN_COUNT } from '../../constants/constants';
 import { HELPER_MESSAGE, PLACE_HOLDER_MESSAGE } from '../../constants/message';
 import useGetRegion from '../../hooks/useGetRegion';
 import usePostModelSignUp from '../../hooks/usePostModelSignUp';
 import Field from '../@common/Field';
+
+import RegionItem from './RegionItem';
 
 import { preferRegionState, regionState } from '@/recoil/atoms/signUpState';
 import Modal from '@/views/@common/components/Modal';

--- a/src/views/SignUpPage/components/3_선호지역선택/RegionItem.tsx
+++ b/src/views/SignUpPage/components/3_선호지역선택/RegionItem.tsx
@@ -1,8 +1,8 @@
 import { useRecoilState } from 'recoil';
 import { styled } from 'styled-components';
 
-import { PREFER_REGION_MAX_COUNT, SELECT_ALL } from '../../SignUpPage/constants/constants';
-import { IcCheckboxBlue, IcCheckboxGrey } from '../assets/icons';
+import { IcCheckboxBlue, IcCheckboxGrey } from '../../../@common/assets/icons';
+import { PREFER_REGION_MAX_COUNT, SELECT_ALL } from '../../constants/constants';
 
 import { preferRegionState } from '@/recoil/atoms/signUpState';
 interface RegionItemProps {


### PR DESCRIPTION
<!-- PR의 제목은 "[페이지명] 구현내용 " 으로, 연결되는 이슈 제목과 동일하게 가져가시면 됩니다! -->

![PR](https://github.com/TEAM-MODDY/moddy-web/assets/81505421/2d53d2e3-fcc8-4b65-835a-b118664382be)

## ▶️ Related Issue

- close #446 

<br />

## ✅ Done Task
- 검증 로직 구현
- 기능 구현

<br />

## 🔎 PR Point

<!-- 리뷰어에게 나의 코드를 설명해주세요 -->
✅주요 컴포넌트
`ModelEditInfoSection`: 페이지 내 최상위 컴포넌트로 모달창과 헤더(버튼 포함) 등을 관리하고 있습니다.
`ModelInfo`: 수정 페이지 내에서 회원 정보를 담고 있는 컴포넌트입니다.

✅검증 로직
민서는 헤더 저장 버튼 클릭할 때마다 토스트 메시지 별도로 띄워지게 설정한 거 같던데
저는 검증과 동시에 토스트 메시지 세팅해놨습니다. 이러면 상태를 하나 줄일 수 있을 것 같았어요
```tsx
  useEffect(() => {
    const checkVerified = () => {
      if (!REGEX.NAME.test(info.name)) {
        setToastMsg(MODEL_TOAST_MESSAGE.NAME);
      } else if (!REGEX.BIRTH_YEAR.test(info.year)) {
        setToastMsg(MODEL_TOAST_MESSAGE.BIRTH_YEAR);
      } else if (!info.preferRegions.length) {
        setToastMsg(MODEL_TOAST_MESSAGE.REGION);
      } else {
        setToastMsg('');
      }
    };

    checkVerified();
  }, [info]);
```

✅ 선호 지역 컴포넌트
원래는 수빈이 거 공통으로 빼려고 했는데 세부 구조가 달라지면서.. 일부문만 쇽샥하고 세부 로직은 전부 수정했습니다..
전역 상태 쓰지 않고 컴포넌트 내 상태로만 관리했다는 게 가장 큰 차이점이겠네요! 그래도 수빈이 로직 최대한 살려서 통일성 주려고 노력했습니다

<br />

## 🧨 Trouble Shooting
<!-- 없으면 삭제 -->
컴포넌트 분리와 로직을 최대한 깔끔하게 짜보고 싶어서 고민을 하다보니 조금 오래 걸렸는데요.
현재는 이게 최선..인데 QA 기간동안 차근차근 다시 한 번 곱씹어보려고 합니당

<br />

## 📸 Screenshot

![moddy, 지출 없이 예쁜 머리 - Chrome 2024-04-29 03-42-43](https://github.com/TEAM-MODDY/moddy-web/assets/101045330/eaae3c0d-4001-4b64-9cd1-b45921ac44dd)

