### PR TITLE
[ApplicationPage] 리코일 초기화 위치 변경

### DIFF
--- a/src/views/ApplicationPage/components/ApplicationResult.tsx
+++ b/src/views/ApplicationPage/components/ApplicationResult.tsx
@@ -7,6 +7,7 @@ import Button from '../../@common/components/Button';
 import Header from '../../@common/components/Header';
 import { INFO_MESSAGE } from '../constants/message';
 import usePostApplication from '../hooks/usePostApplication';
+import useResetApplicationRecoil from '../hooks/useResetApplicationRecoil';
 
 import CaptureSection from './CaptureSection';
 
@@ -15,7 +16,9 @@ import { applyStepState } from '@/recoil/atoms/applicationState';
 const ApplicationResult = () => {
   const [step, setStep] = useRecoilState(applyStepState);
   const navigate = useNavigate();
+  const resetFunc = useResetApplicationRecoil();
   const postApplication = usePostApplication();
+
   const handleApplication = async () => {
     try {
       await postApplication();
@@ -33,6 +36,7 @@ const ApplicationResult = () => {
           setStep({ ...step, current: step.current - 1 });
         }}
         closeFn={() => {
+          resetFunc();
           navigate(`/`);
         }}
       />

--- a/src/views/ApplicationPage/components/ApplicationResult.tsx
+++ b/src/views/ApplicationPage/components/ApplicationResult.tsx
@@ -1,5 +1,5 @@
 import { useNavigate } from 'react-router-dom';
-import { useRecoilState, useResetRecoilState } from 'recoil';
+import { useRecoilState } from 'recoil';
 import { styled } from 'styled-components';
 
 import applyImg from '../../@common/assets/images/img_applylogo.png';
@@ -10,40 +10,15 @@ import usePostApplication from '../hooks/usePostApplication';
 
 import CaptureSection from './CaptureSection';
 
-import {
-  applicationCaptureImgUrlState,
-  applyStepState,
-  deatiledStyleState,
-  hairStyleState,
-  historyState,
-  profileState,
-} from '@/recoil/atoms/applicationState';
+import { applyStepState } from '@/recoil/atoms/applicationState';
 
 const ApplicationResult = () => {
   const [step, setStep] = useRecoilState(applyStepState);
   const navigate = useNavigate();
   const postApplication = usePostApplication();
-  //state 초기화
-  const stepReset = useResetRecoilState(applyStepState);
-  const styleReset = useResetRecoilState(hairStyleState);
-  const detailedStyleReset = useResetRecoilState(deatiledStyleState);
-  const historyReset = useResetRecoilState(historyState);
-  const profileReset = useResetRecoilState(profileState);
-  const imgUrlReset = useResetRecoilState(applicationCaptureImgUrlState);
-
-  const resetAtom = () => {
-    stepReset();
-    styleReset();
-    detailedStyleReset();
-    historyReset();
-    profileReset();
-    imgUrlReset();
-  };
-
   const handleApplication = async () => {
     try {
       await postApplication();
-      resetAtom();
     } catch (err) {
       navigate('/error');
     }

--- a/src/views/ApplicationPage/components/DefaultInfo.tsx
+++ b/src/views/ApplicationPage/components/DefaultInfo.tsx
@@ -9,6 +9,7 @@ import Header from '../../@common/components/Header';
 import ProgressBar from '../../@common/components/ProgressBar';
 import { INFO_MESSAGE } from '../constants/message';
 import { SELECT_LENGTH, SELECT_STYLE } from '../constants/select';
+import useResetApplicationRecoil from '../hooks/useResetApplicationRecoil';
 
 import HairTypeInput from './HairTypeInput';
 import StyleButton from './StyleButton';
@@ -20,6 +21,7 @@ const DefaultInfo = () => {
   const selectedStyle = useRecoilValue(hairStyleState);
   const [isAllVerified, setIsAllVerified] = useState(false);
   const navigate = useNavigate();
+  const resetFunc = useResetApplicationRecoil();
 
   useEffect(() => {
     const checkVerify = () => {
@@ -39,6 +41,10 @@ const DefaultInfo = () => {
         title={INFO_MESSAGE.TITLE}
         isBackBtnExist={true}
         isCloseBtnExist={false}
+        backFn={() => {
+          resetFunc();
+          navigate(-1);
+        }}
         closeFn={() => {
           navigate(`/`);
         }}

--- a/src/views/ApplicationPage/components/DetailedStyle.tsx
+++ b/src/views/ApplicationPage/components/DetailedStyle.tsx
@@ -7,6 +7,7 @@ import Header from '../../@common/components/Header';
 import ProgressBar from '../../@common/components/ProgressBar';
 import TextArea200 from '../../@common/components/TextArea200';
 import { INFO_MESSAGE } from '../constants/message';
+import useResetApplicationRecoil from '../hooks/useResetApplicationRecoil';
 
 import { applyStepState, deatiledStyleState } from '@/recoil/atoms/applicationState';
 
@@ -14,6 +15,7 @@ const DetailedStyle = () => {
   const [step, setStep] = useRecoilState(applyStepState);
   const [hairDetail, setHairDetail] = useRecoilState(deatiledStyleState);
   const navigate = useNavigate();
+  const resetFunc = useResetApplicationRecoil();
 
   return (
     <S.ServiceHistoryLayout>
@@ -25,6 +27,7 @@ const DetailedStyle = () => {
           setStep({ ...step, current: step.current - 1 });
         }}
         closeFn={() => {
+          resetFunc();
           navigate(`/`);
         }}
       />

--- a/src/views/ApplicationPage/components/Profile.tsx
+++ b/src/views/ApplicationPage/components/Profile.tsx
@@ -9,6 +9,7 @@ import Header from '../../@common/components/Header';
 import Input from '../../@common/components/Input';
 import ProgressBar from '../../@common/components/ProgressBar';
 import { INFO_MESSAGE } from '../constants/message';
+import useResetApplicationRecoil from '../hooks/useResetApplicationRecoil';
 
 import { applyStepState, profileState } from '@/recoil/atoms/applicationState';
 import ProfileUpload from '@/views/@common/components/ProfileUpload';
@@ -21,6 +22,7 @@ const Profile = () => {
   const [profileData, setProfileData] = useRecoilState(profileState);
   const [isAllVerified, setIsAllVerified] = useState(false);
   const navigate = useNavigate();
+  const resetFunc = useResetApplicationRecoil();
 
   const handleProfileImg = (imgUrl: string, imgObj: File) => {
     setProfileData({
@@ -48,6 +50,7 @@ const Profile = () => {
           setStep({ ...step, current: step.current - 1 });
         }}
         closeFn={() => {
+          resetFunc();
           navigate(`/`);
         }}
       />

--- a/src/views/ApplicationPage/components/ServiceHistory.tsx
+++ b/src/views/ApplicationPage/components/ServiceHistory.tsx
@@ -6,6 +6,7 @@ import { styled } from 'styled-components';
 import Button from '../../@common/components/Button';
 import Header from '../../@common/components/Header';
 import { INFO_MESSAGE } from '../constants/message';
+import useResetApplicationRecoil from '../hooks/useResetApplicationRecoil';
 
 import ServiceHistoryListItem from './ServiceHistoryListItem';
 
@@ -20,6 +21,7 @@ const ServiceHistory = () => {
   const [step, setStep] = useRecoilState(applyStepState);
   const [serviceHistory, setServiceHistory] = useRecoilState(historyState);
   const navigate = useNavigate();
+  const resetFunc = useResetApplicationRecoil();
 
   const addHistory = () => {
     setServiceHistory((prev) => ({
@@ -48,6 +50,7 @@ const ServiceHistory = () => {
           setStep({ ...step, current: step.current - 1 });
         }}
         closeFn={() => {
+          resetFunc();
           navigate(`/`);
         }}
       />

--- a/src/views/ApplicationPage/hooks/useResetApplicationRecoil.ts
+++ b/src/views/ApplicationPage/hooks/useResetApplicationRecoil.ts
@@ -1,0 +1,33 @@
+import { useResetRecoilState } from 'recoil';
+
+import {
+  applicationCaptureImgUrlState,
+  applyStepState,
+  deatiledStyleState,
+  hairStyleState,
+  historyState,
+  profileState,
+} from '@/recoil/atoms/applicationState';
+
+const useResetApplicationRecoil = () => {
+  //state 초기화
+  const stepReset = useResetRecoilState(applyStepState);
+  const styleReset = useResetRecoilState(hairStyleState);
+  const detailedStyleReset = useResetRecoilState(deatiledStyleState);
+  const historyReset = useResetRecoilState(historyState);
+  const profileReset = useResetRecoilState(profileState);
+  const imgUrlReset = useResetRecoilState(applicationCaptureImgUrlState);
+
+  const resetApplicationAtom = () => {
+    stepReset();
+    styleReset();
+    detailedStyleReset();
+    historyReset();
+    profileReset();
+    imgUrlReset();
+  };
+
+  return resetApplicationAtom;
+};
+
+export default useResetApplicationRecoil;


### PR DESCRIPTION
<!-- PR의 제목은 "[페이지명] 구현내용 " 으로, 연결되는 이슈 제목과 동일하게 가져가시면 됩니다! -->

![PR](https://github.com/TEAM-MODDY/moddy-web/assets/81505421/2d53d2e3-fcc8-4b65-835a-b118664382be)

## ▶️ Related Issue

- close #344 

<br />

## ✅ Done Task
- 리코일 초기화 유틸 함수 생성
- 초기화 시점 변경

<br />

## 🔎 PR Point

<!-- 리뷰어에게 나의 코드를 설명해주세요 -->
💬기존 코드
기존에는 모델 지원을 완료 페이지에서 확인 버튼을 누르면 초기화를 시켰습니다.
이때, 1. 모델 지원 과정 중도 이탈시 2. 확인 안 누르고 뒤로가기 버튼 누를시 ..
등등의 상황에서 전역 상태가 안 지워지고 그대로 남아있다는 문제가 있어서 변경해주었습니다.

💬변경 코드
1. 리코일 초기화 함수 생성
2. x(닫기) 버튼 누를 시에 함수 호출 되도록 해줬습니다
> 훅이 props로 안 넘겨져서 훅 함수 내에서 유틸 함수를 반환값으로 주고 그걸 호출하는 방식을 사용했습니다.

<br />
