### PR TITLE
[QA] 최대 시술 내역 개수 도달시 내역 추가 버튼 삭제

### DIFF
--- a/src/views/ApplicationPage/components/ServiceHistory.tsx
+++ b/src/views/ApplicationPage/components/ServiceHistory.tsx
@@ -24,10 +24,7 @@ const ServiceHistory = () => {
   const addHistory = () => {
     setServiceHistory((prev) => ({
       ...prev,
-      hairServiceRecords:
-        prev.hairServiceRecords.length < MAX_LENGTH
-          ? [...prev.hairServiceRecords, { hairService: '', hairServiceTerm: '' }]
-          : prev.hairServiceRecords,
+      hairServiceRecords: [...prev.hairServiceRecords, { hairService: '', hairServiceTerm: '' }],
     }));
   };
 
@@ -61,9 +58,11 @@ const ServiceHistory = () => {
           <ServiceHistoryListItem key={'history' + item.hairService + item.hairServiceTerm + idx} idx={idx} />
         ))}
       </S.ServiceHistoryList>
-      <S.AddHistoryBtn type="button" onClick={addHistory}>
-        {INFO_MESSAGE.ADD_HISTORY}
-      </S.AddHistoryBtn>
+      {serviceHistory.hairServiceRecords.length < MAX_LENGTH && (
+        <S.AddHistoryBtn type="button" onClick={addHistory}>
+          {INFO_MESSAGE.ADD_HISTORY}
+        </S.AddHistoryBtn>
+      )}
       <Button
         text={INFO_MESSAGE.NEXT}
         isFixed={true}


### PR DESCRIPTION
<!-- PR의 제목은 "[페이지명] 구현내용 " 으로, 연결되는 이슈 제목과 동일하게 가져가시면 됩니다! -->

![PR](https://github.com/TEAM-MODDY/moddy-web/assets/81505421/2d53d2e3-fcc8-4b65-835a-b118664382be)

## ▶️ Related Issue

- close #458

<br />

## ✅ Done Task
- 시술 내역 추가 버튼 삭제

<br />

## 🔎 PR Point

<!-- 리뷰어에게 나의 코드를 설명해주세요 -->
☑**기존 코드**
- 시술 내역 3개까지 추가 가능
- 추가 버튼은 항상 보여주지만 3개 이상으로 리스트가 추가되지는 않음
☑**리팩토링 이후 코드**
- 시술 내역 3개까지 추가 가능
- 시술 내역이 3개가 되면 추가 버튼이 사라짐
```tsx
{serviceHistory.hairServiceRecords.length < MAX_LENGTH && (
  <S.AddHistoryBtn type="button" onClick={addHistory}>
    {INFO_MESSAGE.ADD_HISTORY}
  </S.AddHistoryBtn>
)}
```

<br />


## 📸 Screenshot

<!-- 없으면 삭제 -->
![image](https://github.com/TEAM-MODDY/moddy-web/assets/101045330/327c2a9b-f150-42ae-bcb7-76607a6a7677)
