### PR TITLE
[QA] textarea 한글 글자 수 제한

### DIFF
--- a/src/views/@common/components/TextArea200.tsx
+++ b/src/views/@common/components/TextArea200.tsx
@@ -8,8 +8,18 @@ interface TextArea200Props {
 }
 
 const TextArea200 = ({ placeholderText, initialValue, onChangeFn }: TextArea200Props) => {
+  const MAX_LENGTH = 200;
+
   const [textLength, setTextLength] = useState(initialValue ? initialValue.length : 0);
   const [name, setName] = useState(initialValue ? initialValue : '');
+
+  const textChangeFn = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    const text = e.target.value.length > MAX_LENGTH ? e.target.value.slice(0, MAX_LENGTH) : e.target.value;
+
+    setTextLength(text.length);
+    setName(text);
+    onChangeFn(text);
+  };
 
   return (
     <S.TextAreaLayout>
@@ -17,9 +27,7 @@ const TextArea200 = ({ placeholderText, initialValue, onChangeFn }: TextArea200P
         placeholder={placeholderText}
         defaultValue={name}
         onChange={(e) => {
-          setTextLength(e.target.value.length);
-          setName(e.target.value);
-          onChangeFn(e.target.value);
+          textChangeFn(e);
         }}
         maxLength={200}
       />


### PR DESCRIPTION
<!-- PR의 제목은 "[페이지명] 구현내용 " 으로, 연결되는 이슈 제목과 동일하게 가져가시면 됩니다! -->

![PR](https://github.com/TEAM-MODDY/moddy-web/assets/81505421/2d53d2e3-fcc8-4b65-835a-b118664382be)

## ▶️ Related Issue

- close #459 

<br />

## ✅ Done Task
- 한글 글자 수 제한 함수 추가

<br />

## 🔎 PR Point

기본 textare의 maxLength만을 이용하면 한글로 작성할 때 제한 글자 수를 넘는 경우가 발생했습니다.
1. 외부 영역 클릭 후, textarea의 추가 입력시 한 글자씩 추가 가능
![image](https://github.com/TEAM-MODDY/moddy-web/assets/101045330/a9f766ca-f6ea-4972-bb58-a67a2a4f8e19)
2. 연속적으로 타이핑 시 한글은 201자까지 타이핑 가능
![image](https://github.com/TEAM-MODDY/moddy-web/assets/101045330/b4f0b3cf-538c-4d67-a1f8-60addf1dc9ac)

위의 2가지 경우를 모두 예외 처리해주기 위해 글자 수 제한 함수 로직을 추가했습니다.
❗ **주의** 
→ 한글일 경우에는 예외적으로 처리해줘야함 ! (초성, 중성, 종성 때문에)
→ 브라우저마다 한글 글자수를 다르게 인식하는 경우 때문에 substring 해서 글자수 고려해야 함 

<!-- 리뷰어에게 나의 코드를 설명해주세요 -->
```tsx
//MAX_LENGTH는 최대 글자 수로 별도로 설정
const textChangeFn = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
    const text = e.target.value.length > MAX_LENGTH ? e.target.value.slice(0, MAX_LENGTH) : e.target.value;

    setTextLength(text.length); // 현재 글자 수 
    setName(text); // 화면에 노출되는 값
    onChangeFn(text); // 변수에 저장
};
```

<br />

## 📸 Screenshot

<!-- 없으면 삭제 -->
![image](https://github.com/TEAM-MODDY/moddy-web/assets/101045330/9fb0bb60-16d0-407e-a7bf-6de8abafafb4)
