### PR TITLE
[Refactor] html2canvas chunk 분리 및 tsconfig.node.json 옵션 추가

### DIFF
--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -5,7 +5,7 @@
     "module": "ESNext",
     "moduleResolution": "bundler",
     "allowSyntheticDefaultImports": true,
-    "lib": ["ES2020"]
+    "lib": ["ES2020", "DOM"]
   },
   "include": ["vite.config.ts"]
 }

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -4,7 +4,8 @@
     "skipLibCheck": true,
     "module": "ESNext",
     "moduleResolution": "bundler",
-    "allowSyntheticDefaultImports": true
+    "allowSyntheticDefaultImports": true,
+    "lib": ["ES2020"]
   },
   "include": ["vite.config.ts"]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,4 +6,13 @@ import tsconfigPaths from 'vite-tsconfig-paths';
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react(), svgr({ include: '**/*.svg' }), tsconfigPaths()],
+  build: {
+    rollupOptions: {
+      output: {
+        manualChunks: function (id) {
+          if (id.includes('html2canvas')) return 'html2canvas';
+        },
+      },
+    },
+  },
 });


### PR DESCRIPTION
<!-- PR의 제목은 "[페이지명] 구현내용 " 으로, 연결되는 이슈 제목과 동일하게 가져가시면 됩니다! -->

![PR](https://github.com/TEAM-MODDY/moddy-web/assets/81505421/2d53d2e3-fcc8-4b65-835a-b118664382be)

## ▶️ Related Issue

- close #471 

<br />

## ✅ Done Task
- vite-bundle-visualizer를 통해 번들 구성 체크 
- html2canvas chunk를 분리시키기 위해 rollupOptions.output 추가 
- vite.config.ts에서 발생하는 타입 에러를 해결하고자 tsconfig.node.json에 옵션 추가 

<br />

## 🔎 PR Point

<!-- 리뷰어에게 나의 코드를 설명해주세요 -->

💈**vite-bundle-visualizer를 통해 번들 구성 체크** 
번들 사이즈 체크해주기 위해서 vite-bundle-visualizer npx로 일회성 실행 했어요! 
![image](https://github.com/user-attachments/assets/abe48c9e-4db8-4f8a-8b15-a2e00e076d47)

이렇게 나왔는데 

![image](https://github.com/user-attachments/assets/2cd250cb-7088-4c9d-b535-4198bd06427b)

가장 크게 차지하는 친구가 html2canvas 라이브러리였어요. 

근데 아시다시피 + 보시다시피 저희가 html2canvas를 지원하기 마지막 페이지에서 지원서 캡쳐할때만 사용하잖아요?? 
특정한 기능, 특정한 뷰, 특정한 액션에 의해서만 사용되는 친구인데 초기 번들 사이즈에 가장 많은 영역을 차지해주고 있는게 참 언짢지요 

그래서 chunk를 분리해서 초기 번들에서 빼줬습니다! 


💈 **html2canvas chunk를 분리시키기 위해 rollupOptions.output 추가** 
빌드를 돌리면 터미널에서 500kb가 넘는 청크가 있다 ~ build.rollupOptions.output.manualChunks 를 써서 청킹을 개선해라 ~ 이 경고가 보기 싫으면 build.ChunkSizeWarningLimit 을 바꿔서 청크 사이즈 제한을 조정해라 ~ 라는 워닝이 뜨는걸 볼 수 있어요.

여기서 말하는 build.rollupOptions.output.manualChunks 를 써서 청크를 분리할 수 있어요 

`vite.config.ts `에서 
```ts
build: {
    rollupOptions: {
      output: {
        manualChunks: function (id) {
          if (id.includes('html2canvas')) return 'html2canvas';
        },
      },
    },
  },
```
간단히 말하면 각 청크의 id를 체크해서 혹시 html2canvas 관련 청크를 잡아내면, 얘ㄹ네를 하나로 묶어서 'html2canvas'라는 별도 청크로 분리해줘라! 라는 의미입니다 

아래 스크린샷 보시면 작업 후에 html2canvas ~ 라는 청크가 하나 더 생겼고, 초기 번들인 index-어쩌구 ~ 의 사이즈가 감소한걸 보실 수 있어요! 더불어 빌드 시간도 단축됐습니당 

<br />

## 🧨 Trouble Shooting

<!-- 없으면 삭제 -->
💈 **vite.config.ts에서 발생하는 타입 에러를 해결하고자 tsconfig.node.json에 옵션 추가** 
위의 작업 해주는 과정에서 
string 타입에 includes 메소드가 안먹히는거예요... 
더 어이없는건 다른 파일에서는 다~~ 너무 잘 먹히는데 오로지! vite.config.ts 에서만!! 안먹히더라고요 

하루정도 잡고 끙끙대다가 트러블 슈팅에 성공했는데 
간단히 원인을 말씀드리면 
- `tsconfig.json` : 브라우저 환경에서 실행되는 애 
- `tsconfig.node.json` : node js 환경에서 실행되는 애 -> **vite.config.ts는 node 환경에서 실행되므로 해당 파일의 config를 따름!!** 

그런데 저희가 lib에 ESM 버전을 tsconfig.json에서는 `ES2020` 이라고 명시해줬지만, tsconfig.node.json에서는 lib 명시를 안해줘서 디폴트값인 `ES5 (ES2015)`로 먹히고 있더라고요. string 타입에 includes 메소드가 포함된건 `ES6` 부터라서 vite config 파일에서만 안먹히던거였어요! 

따라서 
tsconfig.json에도 lib 속성 추가해서 배열에 '`ES2020`' 넣어줌으로써 해결했고, 
가끔씩 vite.config.ts 파일에서 console.log 찍으면서 테스트할 일도 있을 것 같아서 
console.log 사용하기 위해 '`DOM`' 도 추가해주었습니당 


<br />

## 📸 Screenshot
🪫 **전** 
![image](https://github.com/user-attachments/assets/f7375359-2f0d-4b7a-93d1-090afd7f20fd)

🔋 **후**
![image](https://github.com/user-attachments/assets/4910b437-c91f-488b-8cf0-353a5553911a)

(아직 부족해요.. 번들링 최적화는 계속됩니다 투비컨티뉴드) 